### PR TITLE
Correctly handle custom User-Agent header

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,17 @@ var client = require('dnsimple')({
 ```
 
 You will need to ensure that you are using an access token created in the sandbox environment. Production tokens will *not* work in the sandbox environment.
+
+
+## Setting a custom `User-Agent` header
+
+You customize the `User-Agent` header for the calls made to the DNSimple API:
+
+```javascript
+var client = require('dnsimple')({
+  user_agent: 'my-app',
+  accessToken: process.env.TOKEN,
+});
+```
+
+The value you provide will be appended to the default `User-Agent` the client uses. For example, if you use `my-app`, the final header value will be `dnsimple-node/2.4.0 my-app` (note that it will vary depending on the client version).

--- a/lib/dnsimple.js
+++ b/lib/dnsimple.js
@@ -22,7 +22,7 @@ const services = {
 Dnsimple.services = services;
 Dnsimple.DEFAULT_TIMEOUT = require('http').createServer().timeout;
 Dnsimple.DEFAULT_BASE_URL = 'https://api.dnsimple.com';
-Dnsimple.DEFAULT_USER_AGENT = 'dnsimple-node/v2';
+Dnsimple.DEFAULT_USER_AGENT = 'dnsimple-node/2.4.0';
 
 function Dnsimple(attrs) {
   if (!(this instanceof Dnsimple)) {

--- a/lib/dnsimple.js
+++ b/lib/dnsimple.js
@@ -69,7 +69,11 @@ Dnsimple.prototype = {
   },
 
   setUserAgent: function(userAgent) {
-    this._api.userAgent = userAgent || Dnsimple.DEFAULT_USER_AGENT;
+    if (!userAgent) {
+      this._api.userAgent = Dnsimple.DEFAULT_USER_AGENT;
+    } else {
+      this._api.userAgent = Dnsimple.DEFAULT_USER_AGENT + ' ' + userAgent;
+    }
   },
 
   _setupServices: function() {

--- a/test/dnsimple.spec.js
+++ b/test/dnsimple.spec.js
@@ -16,4 +16,15 @@ describe('dnsimple module', function() {
     });
   });
 
+  describe('#setUserAgent', function() {
+    it('respects the default User-Agent', function() {
+      expect(dnsimple._api.userAgent).to.equal('dnsimple-node/v2');
+    });
+
+    it('composes the User-Agent', function() {
+      dnsimple.setUserAgent('my-app');
+      expect(dnsimple._api.userAgent).to.equal('dnsimple-node/v2 my-app');
+    });
+  });
+
 });

--- a/test/dnsimple.spec.js
+++ b/test/dnsimple.spec.js
@@ -18,12 +18,12 @@ describe('dnsimple module', function() {
 
   describe('#setUserAgent', function() {
     it('respects the default User-Agent', function() {
-      expect(dnsimple._api.userAgent).to.equal('dnsimple-node/v2');
+      expect(dnsimple._api.userAgent).to.equal('dnsimple-node/2.4.0');
     });
 
     it('composes the User-Agent', function() {
       dnsimple.setUserAgent('my-app');
-      expect(dnsimple._api.userAgent).to.equal('dnsimple-node/v2 my-app');
+      expect(dnsimple._api.userAgent).to.equal('dnsimple-node/2.4.0 my-app');
     });
   });
 


### PR DESCRIPTION
Closes #6 

I've also made sure that the format is the same as in other clients.

I've also wondered if there is a better way of handling the version of the client so we don't have to update the default `User-Agent` and the corresponding tests.