### PR TITLE
only include lib folder when publishing from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "node": ">= v6.0.0"
   },
   "main": "lib/dnsimple.js",
+  "files": [
+    "lib"
+  ],
   "devDependencies": {
     "chai": "~1.10.0",
     "chai-as-promised": "~4.1.1",


### PR DESCRIPTION
This is just a simple PR to include the `files` property in the `package.json` so that npm will only install the necessary files.