### PR TITLE
Update registrar URLs

### DIFF
--- a/lib/dnsimple/registrar.js
+++ b/lib/dnsimple/registrar.js
@@ -78,7 +78,7 @@ class Registrar {
   registerDomain(accountId, domainName, attributes, options = {}) {
     // Note: registrar_id is required, but no validation occurs here.
     // In the ruby library this is validated.
-    return this._client.post(this._registrar_path(accountId, domainName, 'registration'), attributes, options);
+    return this._client.post(this._registrar_path(accountId, domainName, 'registrations'), attributes, options);
   }
 
   /**
@@ -101,7 +101,7 @@ class Registrar {
    * @return {Promise}
    */
   renewDomain(accountId, domainName, attributes, options = {}) {
-    return this._client.post(this._registrar_path(accountId, domainName, 'renewal'), attributes, options);
+    return this._client.post(this._registrar_path(accountId, domainName, 'renewals'), attributes, options);
   }
 
   /**
@@ -126,7 +126,7 @@ class Registrar {
   transferDomain(accountId, domainName, attributes, options = {}) {
     // Note: registrar_id is required, but no validation occurs here.
     // In the ruby library this is validated.
-    return this._client.post(this._registrar_path(accountId, domainName, 'transfer'), attributes, options);
+    return this._client.post(this._registrar_path(accountId, domainName, 'transfers'), attributes, options);
   }
 
   /**
@@ -147,7 +147,7 @@ class Registrar {
    * @return {Promise}
    */
   transferDomainOut(accountId, domainName, options = {}) {
-    return this._client.post(this._registrar_path(accountId, domainName, 'transfer_out'), null, options);
+    return this._client.post(this._registrar_path(accountId, domainName, 'authorize_transfer_out'), null, options);
   }
 
   // Auto-renewal

--- a/test/dnsimple/registrar.spec.js
+++ b/test/dnsimple/registrar.spec.js
@@ -82,7 +82,7 @@ describe('registrar', function() {
       var attributes = {registrant_id: '10'};
 
       nock('https://api.dnsimple.com')
-        .post('/v2/1010/registrar/domains/example.com/registration', attributes)
+        .post('/v2/1010/registrar/domains/example.com/registrations', attributes)
         .reply(fixture.statusCode, fixture.body);
 
       dnsimple.registrar.registerDomain(accountId, domainId, attributes).then(function(response) {
@@ -103,7 +103,7 @@ describe('registrar', function() {
       var attributes = {period: '3'};
 
       nock('https://api.dnsimple.com')
-        .post('/v2/1010/registrar/domains/example.com/renewal', attributes)
+        .post('/v2/1010/registrar/domains/example.com/renewals', attributes)
         .reply(fixture.statusCode, fixture.body);
 
       dnsimple.registrar.renewDomain(accountId, domainId, attributes).then(function(response) {
@@ -123,7 +123,7 @@ describe('registrar', function() {
         var attributes = {};
 
         nock('https://api.dnsimple.com')
-          .post('/v2/1010/registrar/domains/example.com/renewal', attributes)
+          .post('/v2/1010/registrar/domains/example.com/renewals', attributes)
           .reply(fixture.statusCode, fixture.body);
 
         dnsimple.registrar.renewDomain(accountId, domainId, attributes).then(function(response) {
@@ -142,7 +142,7 @@ describe('registrar', function() {
     it('produces a domain', function(done) {
       var fixture = testUtils.fixture('transferDomain/success.http');
       nock('https://api.dnsimple.com')
-        .post('/v2/1010/registrar/domains/example.com/transfer', attributes)
+        .post('/v2/1010/registrar/domains/example.com/transfers', attributes)
         .reply(fixture.statusCode, fixture.body);
 
       dnsimple.registrar.transferDomain(accountId, domainId, attributes).then(function(response) {
@@ -160,7 +160,7 @@ describe('registrar', function() {
 
       it('results in an error', function(done) {
         nock('https://api.dnsimple.com')
-          .post('/v2/1010/registrar/domains/example.com/transfer', attributes)
+          .post('/v2/1010/registrar/domains/example.com/transfers', attributes)
           .reply(fixture.statusCode, fixture.body);
 
         dnsimple.registrar.transferDomain(accountId, domainId, attributes).then(function(response) {
@@ -179,7 +179,7 @@ describe('registrar', function() {
         var attributes = {registrant_id: '10'};
 
         nock('https://api.dnsimple.com')
-          .post('/v2/1010/registrar/domains/example.com/transfer', attributes)
+          .post('/v2/1010/registrar/domains/example.com/transfers', attributes)
           .reply(fixture.statusCode, fixture.body);
 
         dnsimple.registrar.transferDomain(accountId, domainId, attributes).then(function(response) {
@@ -197,7 +197,7 @@ describe('registrar', function() {
 
     it('produces nothing', function(done) {
       nock('https://api.dnsimple.com')
-        .post('/v2/1010/registrar/domains/example.com/transfer_out')
+        .post('/v2/1010/registrar/domains/example.com/authorize_transfer_out')
         .reply(fixture.statusCode, fixture.body);
 
       dnsimple.registrar.transferDomainOut(accountId, domainId).then(function(response) {


### PR DESCRIPTION
The registrar methods were using our old, URLs that we decided to migrate before API v2 GA.
This PR updates the URLs to the public, [documented](https://developer.dnsimple.com/v2/registrar/) ones.

See dnsimple/dnsimple-developer#147