### PR TITLE
Release 3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - "6"
+  - "12"
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 
 node_js:
+  - "8"
+  - "10"
   - "12"
 
 sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Release 3.0.0
+
+- NEW: Updates to support Node v8. Node v6 is deprecated.
+
 ### Release 2.9.0
 
 - NEW: Added WHOIS privacy renewal (GH-17)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Node.JS client for the [DNSimple API v2](https://developer.dnsimple.com/v2/).
 
 ## Requirements
 
-The dnsimple-node package requires node 6.0.0 or higher.
+The dnsimple-node package requires node 8.0.0 or higher.
 
 You must also have an activated DNSimple account to access the DNSimple API.
 

--- a/lib/dnsimple.js
+++ b/lib/dnsimple.js
@@ -19,7 +19,7 @@ const services = {
   zones: require('./dnsimple/zones'),
 };
 
-Dnsimple.VERSION = '2.9.0';
+Dnsimple.VERSION = '3.0.0';
 Dnsimple.DEFAULT_TIMEOUT = require('http').createServer().timeout;
 Dnsimple.DEFAULT_BASE_URL = 'https://api.dnsimple.com';
 Dnsimple.DEFAULT_USER_AGENT = 'dnsimple-node/' + Dnsimple.VERSION;

--- a/package-lock.json
+++ b/package-lock.json
@@ -579,9 +579,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
       "dev": true
     },
     "minimatch": {
@@ -749,9 +749,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "version": "4.17.14",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
           "dev": true
         },
         "pathval": {
@@ -804,55 +804,60 @@
       }
     },
     "npm": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.1.0.tgz",
-      "integrity": "sha512-e38cCtJ0lEjLXXpc4twEfj8Xw5hDLolc2Py87ueWnUhJfZ8GA/5RVIeD+XbSr1+aVRGsRsdtLdzUNO63PvQJ1w==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.10.1.tgz",
+      "integrity": "sha512-ejR83c5aPTip5hPhziypqkJu06vb5tDIugCXx1c5+04RbMjtZeMA6BfsuGnV9EBdEwzKoaHkQ9sJWQAq+LjHYw==",
       "requires": {
-        "JSONStream": "^1.3.2",
+        "JSONStream": "^1.3.5",
         "abbrev": "~1.1.1",
-        "ansi-regex": "~3.0.0",
         "ansicolors": "~0.3.2",
         "ansistyles": "~0.1.3",
-        "aproba": "~1.2.0",
+        "aproba": "^2.0.0",
         "archy": "~1.0.0",
         "bin-links": "^1.1.2",
-        "bluebird": "~3.5.1",
-        "byte-size": "^4.0.3",
-        "cacache": "^11.0.2",
-        "call-limit": "~1.1.0",
-        "chownr": "~1.0.1",
+        "bluebird": "^3.5.5",
+        "byte-size": "^5.0.1",
+        "cacache": "^11.3.3",
+        "call-limit": "^1.1.1",
+        "chownr": "^1.1.2",
+        "ci-info": "^2.0.0",
         "cli-columns": "^3.1.2",
-        "cli-table2": "~0.2.0",
+        "cli-table3": "^0.5.1",
         "cmd-shim": "~2.0.2",
         "columnify": "~1.5.4",
-        "config-chain": "~1.1.11",
+        "config-chain": "^1.1.12",
         "debuglog": "*",
         "detect-indent": "~5.0.0",
         "detect-newline": "^2.1.0",
         "dezalgo": "~1.0.3",
         "editor": "~1.0.0",
-        "figgy-pudding": "^3.1.0",
+        "figgy-pudding": "^3.5.1",
         "find-npm-prefix": "^1.0.2",
         "fs-vacuum": "~1.2.10",
         "fs-write-stream-atomic": "~1.0.10",
         "gentle-fs": "^2.0.1",
-        "glob": "~7.1.2",
-        "graceful-fs": "~4.1.11",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
         "has-unicode": "~2.0.1",
-        "hosted-git-info": "^2.6.0",
-        "iferr": "^1.0.0",
+        "hosted-git-info": "^2.7.1",
+        "iferr": "^1.0.2",
         "imurmurhash": "*",
         "inflight": "~1.0.6",
-        "inherits": "~2.0.3",
+        "inherits": "^2.0.4",
         "ini": "^1.3.5",
         "init-package-json": "^1.10.3",
-        "is-cidr": "^2.0.5",
+        "is-cidr": "^3.0.0",
         "json-parse-better-errors": "^1.0.2",
         "lazy-property": "~1.0.0",
-        "libcipm": "^1.6.2",
-        "libnpmhook": "^4.0.1",
+        "libcipm": "^4.0.0",
+        "libnpm": "^3.0.0",
+        "libnpmaccess": "*",
+        "libnpmhook": "^5.0.2",
+        "libnpmorg": "*",
+        "libnpmsearch": "^2.0.1",
+        "libnpmteam": "*",
         "libnpx": "^10.2.0",
-        "lock-verify": "^2.0.2",
+        "lock-verify": "^2.1.0",
         "lockfile": "^1.0.4",
         "lodash._baseindexof": "*",
         "lodash._baseuniq": "~4.6.0",
@@ -865,95 +870,121 @@
         "lodash.union": "~4.6.0",
         "lodash.uniq": "~4.5.0",
         "lodash.without": "~4.4.0",
-        "lru-cache": "^4.1.3",
+        "lru-cache": "^5.1.1",
         "meant": "~1.0.1",
         "mississippi": "^3.0.0",
         "mkdirp": "~0.5.1",
         "move-concurrently": "^1.0.1",
-        "node-gyp": "^3.6.2",
+        "node-gyp": "^5.0.2",
         "nopt": "~4.0.1",
-        "normalize-package-data": "~2.4.0",
-        "npm-audit-report": "^1.2.1",
+        "normalize-package-data": "^2.5.0",
+        "npm-audit-report": "^1.3.2",
         "npm-cache-filename": "~1.0.2",
         "npm-install-checks": "~3.0.0",
-        "npm-lifecycle": "^2.0.3",
+        "npm-lifecycle": "^3.0.0",
         "npm-package-arg": "^6.1.0",
-        "npm-packlist": "~1.1.10",
-        "npm-pick-manifest": "^2.1.0",
-        "npm-profile": "^3.0.1",
-        "npm-registry-client": "^8.5.1",
-        "npm-registry-fetch": "^1.1.0",
+        "npm-packlist": "^1.4.4",
+        "npm-pick-manifest": "^2.2.3",
+        "npm-profile": "*",
+        "npm-registry-fetch": "^3.9.1",
         "npm-user-validate": "~1.0.0",
         "npmlog": "~4.1.2",
         "once": "~1.4.0",
-        "opener": "~1.4.3",
+        "opener": "^1.5.1",
         "osenv": "^0.1.5",
-        "pacote": "^8.1.5",
+        "pacote": "^9.5.1",
         "path-is-inside": "~1.0.2",
         "promise-inflight": "~1.0.1",
         "qrcode-terminal": "^0.12.0",
-        "query-string": "^6.1.0",
+        "query-string": "^6.8.1",
         "qw": "~1.0.1",
         "read": "~1.0.7",
         "read-cmd-shim": "~1.0.1",
         "read-installed": "~4.0.3",
         "read-package-json": "^2.0.13",
-        "read-package-tree": "^5.2.1",
-        "readable-stream": "^2.3.6",
-        "readdir-scoped-modules": "*",
-        "request": "^2.86.0",
+        "read-package-tree": "^5.3.1",
+        "readable-stream": "^3.4.0",
+        "readdir-scoped-modules": "^1.1.0",
+        "request": "^2.88.0",
         "retry": "^0.12.0",
-        "rimraf": "~2.6.2",
+        "rimraf": "^2.6.3",
         "safe-buffer": "^5.1.2",
-        "semver": "^5.5.0",
-        "sha": "~2.0.1",
+        "semver": "^5.7.0",
+        "sha": "^3.0.0",
         "slide": "~1.1.6",
         "sorted-object": "~2.0.1",
         "sorted-union-stream": "~2.1.3",
-        "ssri": "^6.0.0",
-        "strip-ansi": "~4.0.0",
-        "tar": "^4.4.1",
+        "ssri": "^6.0.1",
+        "stringify-package": "^1.0.0",
+        "tar": "^4.4.10",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "uid-number": "0.0.6",
         "umask": "~1.1.0",
-        "unique-filename": "~1.1.0",
+        "unique-filename": "^1.1.1",
         "unpipe": "~1.0.0",
         "update-notifier": "^2.5.0",
-        "uuid": "^3.2.1",
-        "validate-npm-package-license": "^3.0.3",
+        "uuid": "^3.3.2",
+        "validate-npm-package-license": "^3.0.4",
         "validate-npm-package-name": "~3.0.0",
-        "which": "~1.3.0",
-        "worker-farm": "^1.6.0",
-        "wrappy": "~1.0.2",
-        "write-file-atomic": "^2.3.0"
+        "which": "^1.3.1",
+        "worker-farm": "^1.7.0",
+        "write-file-atomic": "^2.4.3"
       },
       "dependencies": {
         "JSONStream": {
-          "version": "1.3.2",
+          "version": "1.3.5",
           "bundled": true,
           "requires": {
             "jsonparse": "^1.2.0",
             "through": ">=2.2.7 <3"
-          },
-          "dependencies": {
-            "jsonparse": {
-              "version": "1.3.1",
-              "bundled": true
-            },
-            "through": {
-              "version": "2.3.8",
-              "bundled": true
-            }
           }
         },
         "abbrev": {
           "version": "1.1.1",
           "bundled": true
         },
+        "agent-base": {
+          "version": "4.2.1",
+          "bundled": true,
+          "requires": {
+            "es6-promisify": "^5.0.0"
+          }
+        },
+        "agentkeepalive": {
+          "version": "3.4.1",
+          "bundled": true,
+          "requires": {
+            "humanize-ms": "^1.2.1"
+          }
+        },
+        "ajv": {
+          "version": "5.5.2",
+          "bundled": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "ansi-align": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "^2.0.0"
+          }
+        },
         "ansi-regex": {
-          "version": "3.0.0",
+          "version": "2.1.1",
           "bundled": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "bundled": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
         },
         "ansicolors": {
           "version": "0.3.2",
@@ -964,12 +995,81 @@
           "bundled": true
         },
         "aproba": {
-          "version": "1.2.0",
+          "version": "2.0.0",
           "bundled": true
         },
         "archy": {
           "version": "1.0.0",
           "bundled": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "asap": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "asn1": {
+          "version": "0.2.4",
+          "bundled": true,
+          "requires": {
+            "safer-buffer": "~2.1.0"
+          }
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "bundled": true
+        },
+        "aws4": {
+          "version": "1.8.0",
+          "bundled": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "^0.14.3"
+          }
         },
         "bin-links": {
           "version": "1.1.2",
@@ -983,45 +1083,122 @@
           }
         },
         "bluebird": {
-          "version": "3.5.1",
+          "version": "3.5.5",
+          "bundled": true
+        },
+        "boxen": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "ansi-align": "^2.0.0",
+            "camelcase": "^4.0.0",
+            "chalk": "^2.0.1",
+            "cli-boxes": "^1.0.0",
+            "string-width": "^2.0.0",
+            "term-size": "^1.2.0",
+            "widest-line": "^2.0.0"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-from": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "builtins": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "byline": {
+          "version": "5.0.0",
           "bundled": true
         },
         "byte-size": {
-          "version": "4.0.3",
+          "version": "5.0.1",
           "bundled": true
         },
         "cacache": {
-          "version": "11.0.2",
+          "version": "11.3.3",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.1",
-            "chownr": "^1.0.1",
-            "figgy-pudding": "^3.1.0",
-            "glob": "^7.1.2",
-            "graceful-fs": "^4.1.11",
-            "lru-cache": "^4.1.2",
+            "bluebird": "^3.5.5",
+            "chownr": "^1.1.1",
+            "figgy-pudding": "^3.5.1",
+            "glob": "^7.1.4",
+            "graceful-fs": "^4.1.15",
+            "lru-cache": "^5.1.1",
             "mississippi": "^3.0.0",
             "mkdirp": "^0.5.1",
             "move-concurrently": "^1.0.1",
             "promise-inflight": "^1.0.1",
-            "rimraf": "^2.6.2",
-            "ssri": "^6.0.0",
-            "unique-filename": "^1.1.0",
+            "rimraf": "^2.6.3",
+            "ssri": "^6.0.1",
+            "unique-filename": "^1.1.1",
             "y18n": "^4.0.0"
           },
           "dependencies": {
-            "y18n": {
-              "version": "4.0.0",
-              "bundled": true
+            "glob": {
+              "version": "7.1.4",
+              "bundled": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
             }
           }
         },
         "call-limit": {
-          "version": "1.1.0",
+          "version": "1.1.1",
           "bundled": true
         },
+        "camelcase": {
+          "version": "4.1.0",
+          "bundled": true
+        },
+        "capture-stack-trace": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "chownr": {
-          "version": "1.0.1",
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "ci-info": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "cidr-regex": {
+          "version": "2.0.10",
+          "bundled": true,
+          "requires": {
+            "ip-regex": "^2.1.0"
+          }
+        },
+        "cli-boxes": {
+          "version": "1.0.0",
           "bundled": true
         },
         "cli-columns": {
@@ -1030,104 +1207,42 @@
           "requires": {
             "string-width": "^2.0.0",
             "strip-ansi": "^3.0.1"
+          }
+        },
+        "cli-table3": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "colors": "^1.1.2",
+            "object-assign": "^4.1.0",
+            "string-width": "^2.1.1"
+          }
+        },
+        "cliui": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
           },
           "dependencies": {
-            "string-width": {
-              "version": "2.1.1",
-              "bundled": true,
-              "requires": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
-              },
-              "dependencies": {
-                "is-fullwidth-code-point": {
-                  "version": "2.0.0",
-                  "bundled": true
-                },
-                "strip-ansi": {
-                  "version": "4.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "ansi-regex": "^3.0.0"
-                  }
-                }
-              }
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
             },
             "strip-ansi": {
-              "version": "3.0.1",
+              "version": "4.0.0",
               "bundled": true,
               "requires": {
-                "ansi-regex": "^2.0.0"
-              },
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "bundled": true
-                }
+                "ansi-regex": "^3.0.0"
               }
             }
           }
         },
-        "cli-table2": {
-          "version": "0.2.0",
-          "bundled": true,
-          "requires": {
-            "colors": "^1.1.2",
-            "lodash": "^3.10.1",
-            "string-width": "^1.0.1"
-          },
-          "dependencies": {
-            "colors": {
-              "version": "1.1.2",
-              "bundled": true,
-              "optional": true
-            },
-            "lodash": {
-              "version": "3.10.1",
-              "bundled": true
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              },
-              "dependencies": {
-                "code-point-at": {
-                  "version": "1.1.0",
-                  "bundled": true
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "number-is-nan": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "ansi-regex": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            }
-          }
+        "clone": {
+          "version": "1.0.4",
+          "bundled": true
         },
         "cmd-shim": {
           "version": "2.0.2",
@@ -1137,67 +1252,225 @@
             "mkdirp": "~0.5.0"
           }
         },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "color-convert": {
+          "version": "1.9.1",
+          "bundled": true,
+          "requires": {
+            "color-name": "^1.1.1"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "colors": {
+          "version": "1.3.3",
+          "bundled": true,
+          "optional": true
+        },
         "columnify": {
           "version": "1.5.4",
           "bundled": true,
           "requires": {
             "strip-ansi": "^3.0.0",
             "wcwidth": "^1.0.0"
+          }
+        },
+        "combined-stream": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "concat-stream": {
+          "version": "1.6.2",
+          "bundled": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           },
           "dependencies": {
-            "strip-ansi": {
-              "version": "3.0.1",
+            "readable-stream": {
+              "version": "2.3.6",
               "bundled": true,
               "requires": {
-                "ansi-regex": "^2.0.0"
-              },
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "bundled": true
-                }
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
               }
             },
-            "wcwidth": {
-              "version": "1.0.1",
+            "string_decoder": {
+              "version": "1.1.1",
               "bundled": true,
               "requires": {
-                "defaults": "^1.0.3"
-              },
-              "dependencies": {
-                "defaults": {
-                  "version": "1.0.3",
-                  "bundled": true,
-                  "requires": {
-                    "clone": "^1.0.2"
-                  },
-                  "dependencies": {
-                    "clone": {
-                      "version": "1.0.2",
-                      "bundled": true
-                    }
-                  }
-                }
+                "safe-buffer": "~5.1.0"
               }
             }
           }
         },
         "config-chain": {
-          "version": "1.1.11",
+          "version": "1.1.12",
           "bundled": true,
           "requires": {
             "ini": "^1.3.4",
             "proto-list": "~1.2.1"
+          }
+        },
+        "configstore": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "dot-prop": "^4.1.0",
+            "graceful-fs": "^4.1.2",
+            "make-dir": "^1.0.0",
+            "unique-string": "^1.0.0",
+            "write-file-atomic": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
+          }
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "copy-concurrently": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "aproba": "^1.1.1",
+            "fs-write-stream-atomic": "^1.0.8",
+            "iferr": "^0.1.5",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.5.4",
+            "run-queue": "^1.0.0"
           },
           "dependencies": {
-            "proto-list": {
-              "version": "1.2.4",
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "iferr": {
+              "version": "0.1.5",
+              "bundled": true
+            }
+          }
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "create-error-class": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "capture-stack-trace": "^1.0.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "bundled": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "4.1.5",
+              "bundled": true,
+              "requires": {
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
+              }
+            },
+            "yallist": {
+              "version": "2.1.2",
+              "bundled": true
+            }
+          }
+        },
+        "crypto-random-string": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "cyclist": {
+          "version": "0.2.2",
+          "bundled": true
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
               "bundled": true
             }
           }
         },
         "debuglog": {
           "version": "1.0.1",
+          "bundled": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "decode-uri-component": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "deep-extend": {
+          "version": "0.5.1",
+          "bundled": true
+        },
+        "defaults": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "clone": "^1.0.2"
+          }
+        },
+        "define-properties": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "object-keys": "^1.0.12"
+          }
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "delegates": {
+          "version": "1.0.0",
           "bundled": true
         },
         "detect-indent": {
@@ -1214,25 +1487,261 @@
           "requires": {
             "asap": "^2.0.0",
             "wrappy": "1"
+          }
+        },
+        "dot-prop": {
+          "version": "4.2.0",
+          "bundled": true,
+          "requires": {
+            "is-obj": "^1.0.0"
+          }
+        },
+        "dotenv": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "duplexer3": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "duplexify": {
+          "version": "3.6.0",
+          "bundled": true,
+          "requires": {
+            "end-of-stream": "^1.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0",
+            "stream-shift": "^1.0.0"
           },
           "dependencies": {
-            "asap": {
-              "version": "2.0.5",
-              "bundled": true
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
             }
+          }
+        },
+        "ecc-jsbn": {
+          "version": "0.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.1.0"
           }
         },
         "editor": {
           "version": "1.0.0",
           "bundled": true
         },
+        "encoding": {
+          "version": "0.1.12",
+          "bundled": true,
+          "requires": {
+            "iconv-lite": "~0.4.13"
+          }
+        },
+        "end-of-stream": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "once": "^1.4.0"
+          }
+        },
+        "env-paths": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "err-code": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "errno": {
+          "version": "0.1.7",
+          "bundled": true,
+          "requires": {
+            "prr": "~1.0.1"
+          }
+        },
+        "es-abstract": {
+          "version": "1.12.0",
+          "bundled": true,
+          "requires": {
+            "es-to-primitive": "^1.1.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.1",
+            "is-callable": "^1.1.3",
+            "is-regex": "^1.0.4"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "es6-promise": {
+          "version": "4.2.6",
+          "bundled": true
+        },
+        "es6-promisify": {
+          "version": "5.0.0",
+          "bundled": true,
+          "requires": {
+            "es6-promise": "^4.0.3"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "execa": {
+          "version": "0.7.0",
+          "bundled": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "extend": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "extsprintf": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.0.0",
+          "bundled": true
+        },
         "figgy-pudding": {
-          "version": "3.1.0",
+          "version": "3.5.1",
           "bundled": true
         },
         "find-npm-prefix": {
           "version": "1.0.2",
           "bundled": true
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "flush-write-stream": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.4"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "form-data": {
+          "version": "2.3.2",
+          "bundled": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "from2": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "fs-minipass": {
+          "version": "1.2.6",
+          "bundled": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
         },
         "fs-vacuum": {
           "version": "1.2.10",
@@ -1256,8 +1765,69 @@
             "iferr": {
               "version": "0.1.5",
               "bundled": true
+            },
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
             }
           }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "function-bind": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            }
+          }
+        },
+        "genfun": {
+          "version": "5.0.0",
+          "bundled": true
         },
         "gentle-fs": {
           "version": "2.0.1",
@@ -1273,14 +1843,36 @@
             "slide": "^1.1.6"
           },
           "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true
+            },
             "iferr": {
               "version": "0.1.5",
               "bundled": true
             }
           }
         },
+        "get-caller-file": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
         "glob": {
-          "version": "7.1.2",
+          "version": "7.1.4",
           "bundled": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -1289,47 +1881,67 @@
             "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
+          }
+        },
+        "global-dirs": {
+          "version": "0.1.1",
+          "bundled": true,
+          "requires": {
+            "ini": "^1.3.4"
+          }
+        },
+        "got": {
+          "version": "6.7.1",
+          "bundled": true,
+          "requires": {
+            "create-error-class": "^3.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "unzip-response": "^2.0.1",
+            "url-parse-lax": "^1.0.0"
           },
           "dependencies": {
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.8",
-                  "bundled": true,
-                  "requires": {
-                    "balanced-match": "^1.0.0",
-                    "concat-map": "0.0.1"
-                  },
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
+            "get-stream": {
+              "version": "3.0.0",
               "bundled": true
             }
           }
         },
         "graceful-fs": {
-          "version": "4.1.11",
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "har-validator": {
+          "version": "5.1.0",
+          "bundled": true,
+          "requires": {
+            "ajv": "^5.3.0",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "has-symbols": {
+          "version": "1.0.0",
           "bundled": true
         },
         "has-unicode": {
@@ -1337,11 +1949,65 @@
           "bundled": true
         },
         "hosted-git-info": {
-          "version": "2.6.0",
+          "version": "2.7.1",
           "bundled": true
         },
+        "http-cache-semantics": {
+          "version": "3.8.1",
+          "bundled": true
+        },
+        "http-proxy-agent": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "agent-base": "4",
+            "debug": "3.1.0"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "agent-base": "^4.1.0",
+            "debug": "^3.1.0"
+          }
+        },
+        "humanize-ms": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "ms": "^2.0.0"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.23",
+          "bundled": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
         "iferr": {
-          "version": "1.0.0",
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "import-lazy": {
+          "version": "2.1.0",
           "bundled": true
         },
         "imurmurhash": {
@@ -1357,7 +2023,7 @@
           }
         },
         "inherits": {
-          "version": "2.0.3",
+          "version": "2.0.4",
           "bundled": true
         },
         "ini": {
@@ -1376,956 +2042,343 @@
             "semver": "2.x || 3.x || 4 || 5",
             "validate-npm-package-license": "^3.0.1",
             "validate-npm-package-name": "^3.0.0"
+          }
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "ip": {
+          "version": "1.1.5",
+          "bundled": true
+        },
+        "ip-regex": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "is-callable": {
+          "version": "1.1.4",
+          "bundled": true
+        },
+        "is-ci": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "ci-info": "^1.0.0"
           },
           "dependencies": {
-            "promzard": {
-              "version": "0.3.0",
-              "bundled": true,
-              "requires": {
-                "read": "1"
-              }
+            "ci-info": {
+              "version": "1.6.0",
+              "bundled": true
             }
           }
         },
         "is-cidr": {
-          "version": "2.0.5",
+          "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "cidr-regex": "^2.0.8"
-          },
-          "dependencies": {
-            "cidr-regex": {
-              "version": "2.0.8",
-              "bundled": true,
-              "requires": {
-                "ip-regex": "^2.1.0"
-              },
-              "dependencies": {
-                "ip-regex": {
-                  "version": "2.1.0",
-                  "bundled": true
-                }
-              }
-            }
+            "cidr-regex": "^2.0.10"
           }
+        },
+        "is-date-object": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "is-installed-globally": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "global-dirs": "^0.1.0",
+            "is-path-inside": "^1.0.0"
+          }
+        },
+        "is-npm": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-obj": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-path-inside": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "path-is-inside": "^1.0.1"
+          }
+        },
+        "is-redirect": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-regex": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "has": "^1.0.1"
+          }
+        },
+        "is-retry-allowed": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-symbol": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "has-symbols": "^1.0.0"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
         },
         "json-parse-better-errors": {
           "version": "1.0.2",
           "bundled": true
         },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "jsonparse": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "jsprim": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          }
+        },
+        "latest-version": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "package-json": "^4.0.0"
+          }
+        },
         "lazy-property": {
           "version": "1.0.0",
           "bundled": true
         },
-        "libcipm": {
-          "version": "1.6.2",
+        "lcid": {
+          "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "bin-links": "^1.1.0",
+            "invert-kv": "^1.0.0"
+          }
+        },
+        "libcipm": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "bin-links": "^1.1.2",
             "bluebird": "^3.5.1",
+            "figgy-pudding": "^3.5.1",
             "find-npm-prefix": "^1.0.2",
             "graceful-fs": "^4.1.11",
-            "lock-verify": "^2.0.0",
-            "npm-lifecycle": "^2.0.0",
+            "ini": "^1.3.5",
+            "lock-verify": "^2.0.2",
+            "mkdirp": "^0.5.1",
+            "npm-lifecycle": "^3.0.0",
             "npm-logical-tree": "^1.2.1",
-            "npm-package-arg": "^6.0.0",
-            "pacote": "^7.5.1",
-            "protoduck": "^5.0.0",
-            "read-package-json": "^2.0.12",
+            "npm-package-arg": "^6.1.0",
+            "pacote": "^9.1.0",
+            "read-package-json": "^2.0.13",
             "rimraf": "^2.6.2",
-            "worker-farm": "^1.5.4"
+            "worker-farm": "^1.6.0"
+          }
+        },
+        "libnpm": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "bin-links": "^1.1.2",
+            "bluebird": "^3.5.3",
+            "find-npm-prefix": "^1.0.2",
+            "libnpmaccess": "^3.0.1",
+            "libnpmconfig": "^1.2.1",
+            "libnpmhook": "^5.0.2",
+            "libnpmorg": "^1.0.0",
+            "libnpmpublish": "^1.1.0",
+            "libnpmsearch": "^2.0.0",
+            "libnpmteam": "^1.0.1",
+            "lock-verify": "^2.0.2",
+            "npm-lifecycle": "^3.0.0",
+            "npm-logical-tree": "^1.2.1",
+            "npm-package-arg": "^6.1.0",
+            "npm-profile": "^4.0.1",
+            "npm-registry-fetch": "^3.8.0",
+            "npmlog": "^4.1.2",
+            "pacote": "^9.2.3",
+            "read-package-json": "^2.0.13",
+            "stringify-package": "^1.0.0"
+          }
+        },
+        "libnpmaccess": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "get-stream": "^4.0.0",
+            "npm-package-arg": "^6.1.0",
+            "npm-registry-fetch": "^3.8.0"
           },
           "dependencies": {
-            "npm-logical-tree": {
-              "version": "1.2.1",
+            "aproba": {
+              "version": "2.0.0",
               "bundled": true
-            },
-            "pacote": {
-              "version": "7.6.1",
+            }
+          }
+        },
+        "libnpmconfig": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "figgy-pudding": "^3.5.1",
+            "find-up": "^3.0.0",
+            "ini": "^1.3.5"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "bluebird": "^3.5.1",
-                "cacache": "^10.0.4",
-                "get-stream": "^3.0.0",
-                "glob": "^7.1.2",
-                "lru-cache": "^4.1.1",
-                "make-fetch-happen": "^2.6.0",
-                "minimatch": "^3.0.4",
-                "mississippi": "^3.0.0",
-                "mkdirp": "^0.5.1",
-                "normalize-package-data": "^2.4.0",
-                "npm-package-arg": "^6.0.0",
-                "npm-packlist": "^1.1.10",
-                "npm-pick-manifest": "^2.1.0",
-                "osenv": "^0.1.5",
-                "promise-inflight": "^1.0.1",
-                "promise-retry": "^1.1.1",
-                "protoduck": "^5.0.0",
-                "rimraf": "^2.6.2",
-                "safe-buffer": "^5.1.1",
-                "semver": "^5.5.0",
-                "ssri": "^5.2.4",
-                "tar": "^4.4.0",
-                "unique-filename": "^1.1.0",
-                "which": "^1.3.0"
-              },
-              "dependencies": {
-                "cacache": {
-                  "version": "10.0.4",
-                  "bundled": true,
-                  "requires": {
-                    "bluebird": "^3.5.1",
-                    "chownr": "^1.0.1",
-                    "glob": "^7.1.2",
-                    "graceful-fs": "^4.1.11",
-                    "lru-cache": "^4.1.1",
-                    "mississippi": "^2.0.0",
-                    "mkdirp": "^0.5.1",
-                    "move-concurrently": "^1.0.1",
-                    "promise-inflight": "^1.0.1",
-                    "rimraf": "^2.6.2",
-                    "ssri": "^5.2.4",
-                    "unique-filename": "^1.1.0",
-                    "y18n": "^4.0.0"
-                  },
-                  "dependencies": {
-                    "mississippi": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "concat-stream": "^1.5.0",
-                        "duplexify": "^3.4.2",
-                        "end-of-stream": "^1.1.0",
-                        "flush-write-stream": "^1.0.0",
-                        "from2": "^2.1.0",
-                        "parallel-transform": "^1.1.0",
-                        "pump": "^2.0.1",
-                        "pumpify": "^1.3.3",
-                        "stream-each": "^1.1.0",
-                        "through2": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "concat-stream": {
-                          "version": "1.6.2",
-                          "bundled": true,
-                          "requires": {
-                            "buffer-from": "^1.0.0",
-                            "inherits": "^2.0.3",
-                            "readable-stream": "^2.2.2",
-                            "typedarray": "^0.0.6"
-                          },
-                          "dependencies": {
-                            "buffer-from": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            },
-                            "typedarray": {
-                              "version": "0.0.6",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "duplexify": {
-                          "version": "3.5.4",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "^1.0.0",
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.0",
-                            "stream-shift": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "stream-shift": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "end-of-stream": {
-                          "version": "1.4.1",
-                          "bundled": true,
-                          "requires": {
-                            "once": "^1.4.0"
-                          }
-                        },
-                        "flush-write-stream": {
-                          "version": "1.0.3",
-                          "bundled": true,
-                          "requires": {
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.4"
-                          }
-                        },
-                        "from2": {
-                          "version": "2.3.0",
-                          "bundled": true,
-                          "requires": {
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.0"
-                          }
-                        },
-                        "parallel-transform": {
-                          "version": "1.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "cyclist": "~0.2.2",
-                            "inherits": "^2.0.3",
-                            "readable-stream": "^2.1.5"
-                          },
-                          "dependencies": {
-                            "cyclist": {
-                              "version": "0.2.2",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "pump": {
-                          "version": "2.0.1",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "once": "^1.3.1"
-                          }
-                        },
-                        "pumpify": {
-                          "version": "1.4.0",
-                          "bundled": true,
-                          "requires": {
-                            "duplexify": "^3.5.3",
-                            "inherits": "^2.0.3",
-                            "pump": "^2.0.0"
-                          }
-                        },
-                        "stream-each": {
-                          "version": "1.2.2",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "stream-shift": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "stream-shift": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "through2": {
-                          "version": "2.0.3",
-                          "bundled": true,
-                          "requires": {
-                            "readable-stream": "^2.1.5",
-                            "xtend": "~4.0.1"
-                          },
-                          "dependencies": {
-                            "xtend": {
-                              "version": "4.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "y18n": {
-                      "version": "4.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "get-stream": {
-                  "version": "3.0.0",
-                  "bundled": true
-                },
-                "make-fetch-happen": {
-                  "version": "2.6.0",
-                  "bundled": true,
-                  "requires": {
-                    "agentkeepalive": "^3.3.0",
-                    "cacache": "^10.0.0",
-                    "http-cache-semantics": "^3.8.0",
-                    "http-proxy-agent": "^2.0.0",
-                    "https-proxy-agent": "^2.1.0",
-                    "lru-cache": "^4.1.1",
-                    "mississippi": "^1.2.0",
-                    "node-fetch-npm": "^2.0.2",
-                    "promise-retry": "^1.1.1",
-                    "socks-proxy-agent": "^3.0.1",
-                    "ssri": "^5.0.0"
-                  },
-                  "dependencies": {
-                    "agentkeepalive": {
-                      "version": "3.4.1",
-                      "bundled": true,
-                      "requires": {
-                        "humanize-ms": "^1.2.1"
-                      },
-                      "dependencies": {
-                        "humanize-ms": {
-                          "version": "1.2.1",
-                          "bundled": true,
-                          "requires": {
-                            "ms": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.1.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "http-cache-semantics": {
-                      "version": "3.8.1",
-                      "bundled": true
-                    },
-                    "http-proxy-agent": {
-                      "version": "2.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "agent-base": "4",
-                        "debug": "3.1.0"
-                      },
-                      "dependencies": {
-                        "agent-base": {
-                          "version": "4.2.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promisify": "^5.0.0"
-                          },
-                          "dependencies": {
-                            "es6-promisify": {
-                              "version": "5.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "es6-promise": "^4.0.3"
-                              },
-                              "dependencies": {
-                                "es6-promise": {
-                                  "version": "4.2.4",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "debug": {
-                          "version": "3.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "ms": "2.0.0"
-                          },
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.0.0",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "https-proxy-agent": {
-                      "version": "2.2.1",
-                      "bundled": true,
-                      "requires": {
-                        "agent-base": "^4.1.0",
-                        "debug": "^3.1.0"
-                      },
-                      "dependencies": {
-                        "agent-base": {
-                          "version": "4.2.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promisify": "^5.0.0"
-                          },
-                          "dependencies": {
-                            "es6-promisify": {
-                              "version": "5.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "es6-promise": "^4.0.3"
-                              },
-                              "dependencies": {
-                                "es6-promise": {
-                                  "version": "4.2.4",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "debug": {
-                          "version": "3.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "ms": "2.0.0"
-                          },
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.0.0",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "mississippi": {
-                      "version": "1.3.1",
-                      "bundled": true,
-                      "requires": {
-                        "concat-stream": "^1.5.0",
-                        "duplexify": "^3.4.2",
-                        "end-of-stream": "^1.1.0",
-                        "flush-write-stream": "^1.0.0",
-                        "from2": "^2.1.0",
-                        "parallel-transform": "^1.1.0",
-                        "pump": "^1.0.0",
-                        "pumpify": "^1.3.3",
-                        "stream-each": "^1.1.0",
-                        "through2": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "concat-stream": {
-                          "version": "1.6.2",
-                          "bundled": true,
-                          "requires": {
-                            "buffer-from": "^1.0.0",
-                            "inherits": "^2.0.3",
-                            "readable-stream": "^2.2.2",
-                            "typedarray": "^0.0.6"
-                          },
-                          "dependencies": {
-                            "buffer-from": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            },
-                            "typedarray": {
-                              "version": "0.0.6",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "duplexify": {
-                          "version": "3.5.4",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "^1.0.0",
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.0",
-                            "stream-shift": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "stream-shift": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "end-of-stream": {
-                          "version": "1.4.1",
-                          "bundled": true,
-                          "requires": {
-                            "once": "^1.4.0"
-                          }
-                        },
-                        "flush-write-stream": {
-                          "version": "1.0.3",
-                          "bundled": true,
-                          "requires": {
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.4"
-                          }
-                        },
-                        "from2": {
-                          "version": "2.3.0",
-                          "bundled": true,
-                          "requires": {
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.0"
-                          }
-                        },
-                        "parallel-transform": {
-                          "version": "1.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "cyclist": "~0.2.2",
-                            "inherits": "^2.0.3",
-                            "readable-stream": "^2.1.5"
-                          },
-                          "dependencies": {
-                            "cyclist": {
-                              "version": "0.2.2",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "pump": {
-                          "version": "1.0.3",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "once": "^1.3.1"
-                          }
-                        },
-                        "pumpify": {
-                          "version": "1.4.0",
-                          "bundled": true,
-                          "requires": {
-                            "duplexify": "^3.5.3",
-                            "inherits": "^2.0.3",
-                            "pump": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "pump": {
-                              "version": "2.0.1",
-                              "bundled": true,
-                              "requires": {
-                                "end-of-stream": "^1.1.0",
-                                "once": "^1.3.1"
-                              }
-                            }
-                          }
-                        },
-                        "stream-each": {
-                          "version": "1.2.2",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "stream-shift": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "stream-shift": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "through2": {
-                          "version": "2.0.3",
-                          "bundled": true,
-                          "requires": {
-                            "readable-stream": "^2.1.5",
-                            "xtend": "~4.0.1"
-                          },
-                          "dependencies": {
-                            "xtend": {
-                              "version": "4.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "node-fetch-npm": {
-                      "version": "2.0.2",
-                      "bundled": true,
-                      "requires": {
-                        "encoding": "^0.1.11",
-                        "json-parse-better-errors": "^1.0.0",
-                        "safe-buffer": "^5.1.1"
-                      },
-                      "dependencies": {
-                        "encoding": {
-                          "version": "0.1.12",
-                          "bundled": true,
-                          "requires": {
-                            "iconv-lite": "~0.4.13"
-                          },
-                          "dependencies": {
-                            "iconv-lite": {
-                              "version": "0.4.21",
-                              "bundled": true,
-                              "requires": {
-                                "safer-buffer": "^2.1.0"
-                              },
-                              "dependencies": {
-                                "safer-buffer": {
-                                  "version": "2.1.2",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "socks-proxy-agent": {
-                      "version": "3.0.1",
-                      "bundled": true,
-                      "requires": {
-                        "agent-base": "^4.1.0",
-                        "socks": "^1.1.10"
-                      },
-                      "dependencies": {
-                        "agent-base": {
-                          "version": "4.2.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promisify": "^5.0.0"
-                          },
-                          "dependencies": {
-                            "es6-promisify": {
-                              "version": "5.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "es6-promise": "^4.0.3"
-                              },
-                              "dependencies": {
-                                "es6-promise": {
-                                  "version": "4.2.4",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "socks": {
-                          "version": "1.1.10",
-                          "bundled": true,
-                          "requires": {
-                            "ip": "^1.1.4",
-                            "smart-buffer": "^1.0.13"
-                          },
-                          "dependencies": {
-                            "ip": {
-                              "version": "1.1.5",
-                              "bundled": true
-                            },
-                            "smart-buffer": {
-                              "version": "1.1.15",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "3.0.4",
-                  "bundled": true,
-                  "requires": {
-                    "brace-expansion": "^1.1.7"
-                  },
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.11",
-                      "bundled": true,
-                      "requires": {
-                        "balanced-match": "^1.0.0",
-                        "concat-map": "0.0.1"
-                      },
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "promise-retry": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "err-code": "^1.0.0",
-                    "retry": "^0.10.0"
-                  },
-                  "dependencies": {
-                    "err-code": {
-                      "version": "1.1.2",
-                      "bundled": true
-                    },
-                    "retry": {
-                      "version": "0.10.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "ssri": {
-                  "version": "5.3.0",
-                  "bundled": true,
-                  "requires": {
-                    "safe-buffer": "^5.1.1"
-                  }
-                }
+                "locate-path": "^3.0.0"
               }
             },
-            "protoduck": {
-              "version": "5.0.0",
+            "locate-path": {
+              "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "genfun": "^4.0.1"
-              },
-              "dependencies": {
-                "genfun": {
-                  "version": "4.0.1",
-                  "bundled": true
-                }
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
               }
+            },
+            "p-limit": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "p-try": {
+              "version": "2.2.0",
+              "bundled": true
             }
           }
         },
         "libnpmhook": {
-          "version": "4.0.1",
+          "version": "5.0.2",
           "bundled": true,
           "requires": {
-            "figgy-pudding": "^3.1.0",
-            "npm-registry-fetch": "^3.0.0"
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.4.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^3.8.0"
+          }
+        },
+        "libnpmorg": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.4.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^3.8.0"
           },
           "dependencies": {
-            "npm-registry-fetch": {
-              "version": "3.1.1",
-              "bundled": true,
-              "requires": {
-                "bluebird": "^3.5.1",
-                "figgy-pudding": "^3.1.0",
-                "lru-cache": "^4.1.2",
-                "make-fetch-happen": "^4.0.0",
-                "npm-package-arg": "^6.0.0"
-              },
-              "dependencies": {
-                "make-fetch-happen": {
-                  "version": "4.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "agentkeepalive": "^3.4.1",
-                    "cacache": "^11.0.1",
-                    "http-cache-semantics": "^3.8.1",
-                    "http-proxy-agent": "^2.1.0",
-                    "https-proxy-agent": "^2.2.1",
-                    "lru-cache": "^4.1.2",
-                    "mississippi": "^3.0.0",
-                    "node-fetch-npm": "^2.0.2",
-                    "promise-retry": "^1.1.1",
-                    "socks-proxy-agent": "^4.0.0",
-                    "ssri": "^6.0.0"
-                  },
-                  "dependencies": {
-                    "agentkeepalive": {
-                      "version": "3.4.1",
-                      "bundled": true,
-                      "requires": {
-                        "humanize-ms": "^1.2.1"
-                      },
-                      "dependencies": {
-                        "humanize-ms": {
-                          "version": "1.2.1",
-                          "bundled": true,
-                          "requires": {
-                            "ms": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.1.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "http-cache-semantics": {
-                      "version": "3.8.1",
-                      "bundled": true
-                    },
-                    "http-proxy-agent": {
-                      "version": "2.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "agent-base": "4",
-                        "debug": "3.1.0"
-                      },
-                      "dependencies": {
-                        "agent-base": {
-                          "version": "4.2.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promisify": "^5.0.0"
-                          },
-                          "dependencies": {
-                            "es6-promisify": {
-                              "version": "5.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "es6-promise": "^4.0.3"
-                              },
-                              "dependencies": {
-                                "es6-promise": {
-                                  "version": "4.2.4",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "debug": {
-                          "version": "3.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "ms": "2.0.0"
-                          },
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.0.0",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "https-proxy-agent": {
-                      "version": "2.2.1",
-                      "bundled": true,
-                      "requires": {
-                        "agent-base": "^4.1.0",
-                        "debug": "^3.1.0"
-                      },
-                      "dependencies": {
-                        "agent-base": {
-                          "version": "4.2.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promisify": "^5.0.0"
-                          },
-                          "dependencies": {
-                            "es6-promisify": {
-                              "version": "5.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "es6-promise": "^4.0.3"
-                              },
-                              "dependencies": {
-                                "es6-promise": {
-                                  "version": "4.2.4",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "debug": {
-                          "version": "3.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "ms": "2.0.0"
-                          },
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.0.0",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "node-fetch-npm": {
-                      "version": "2.0.2",
-                      "bundled": true,
-                      "requires": {
-                        "encoding": "^0.1.11",
-                        "json-parse-better-errors": "^1.0.0",
-                        "safe-buffer": "^5.1.1"
-                      },
-                      "dependencies": {
-                        "encoding": {
-                          "version": "0.1.12",
-                          "bundled": true,
-                          "requires": {
-                            "iconv-lite": "~0.4.13"
-                          },
-                          "dependencies": {
-                            "iconv-lite": {
-                              "version": "0.4.21",
-                              "bundled": true,
-                              "requires": {
-                                "safer-buffer": "^2.1.0"
-                              },
-                              "dependencies": {
-                                "safer-buffer": {
-                                  "version": "2.1.2",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "promise-retry": {
-                      "version": "1.1.1",
-                      "bundled": true,
-                      "requires": {
-                        "err-code": "^1.0.0",
-                        "retry": "^0.10.0"
-                      },
-                      "dependencies": {
-                        "err-code": {
-                          "version": "1.1.2",
-                          "bundled": true
-                        },
-                        "retry": {
-                          "version": "0.10.1",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "socks-proxy-agent": {
-                      "version": "4.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "agent-base": "~4.1.0",
-                        "socks": "~2.1.6"
-                      },
-                      "dependencies": {
-                        "agent-base": {
-                          "version": "4.1.2",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promisify": "^5.0.0"
-                          },
-                          "dependencies": {
-                            "es6-promisify": {
-                              "version": "5.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "es6-promise": "^4.0.3"
-                              },
-                              "dependencies": {
-                                "es6-promise": {
-                                  "version": "4.2.4",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "socks": {
-                          "version": "2.1.6",
-                          "bundled": true,
-                          "requires": {
-                            "ip": "^1.1.5",
-                            "smart-buffer": "^4.0.1"
-                          },
-                          "dependencies": {
-                            "ip": {
-                              "version": "1.1.5",
-                              "bundled": true
-                            },
-                            "smart-buffer": {
-                              "version": "4.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
+            "aproba": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "libnpmpublish": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.5.1",
+            "get-stream": "^4.0.0",
+            "lodash.clonedeep": "^4.5.0",
+            "normalize-package-data": "^2.4.0",
+            "npm-package-arg": "^6.1.0",
+            "npm-registry-fetch": "^3.8.0",
+            "semver": "^5.5.1",
+            "ssri": "^6.0.1"
+          }
+        },
+        "libnpmsearch": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "figgy-pudding": "^3.5.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^3.8.0"
+          }
+        },
+        "libnpmteam": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.4.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^3.8.0"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "2.0.0",
+              "bundled": true
             }
           }
         },
@@ -2341,314 +2394,21 @@
             "which": "^1.3.0",
             "y18n": "^4.0.0",
             "yargs": "^11.0.0"
-          },
-          "dependencies": {
-            "dotenv": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "y18n": {
-              "version": "4.0.0",
-              "bundled": true
-            },
-            "yargs": {
-              "version": "11.0.0",
-              "bundled": true,
-              "requires": {
-                "cliui": "^4.0.0",
-                "decamelize": "^1.1.1",
-                "find-up": "^2.1.0",
-                "get-caller-file": "^1.0.1",
-                "os-locale": "^2.0.0",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^1.0.1",
-                "set-blocking": "^2.0.0",
-                "string-width": "^2.0.0",
-                "which-module": "^2.0.0",
-                "y18n": "^3.2.1",
-                "yargs-parser": "^9.0.2"
-              },
-              "dependencies": {
-                "cliui": {
-                  "version": "4.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "string-width": "^2.1.1",
-                    "strip-ansi": "^4.0.0",
-                    "wrap-ansi": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "wrap-ansi": {
-                      "version": "2.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1"
-                      },
-                      "dependencies": {
-                        "string-width": {
-                          "version": "1.0.2",
-                          "bundled": true,
-                          "requires": {
-                            "code-point-at": "^1.0.0",
-                            "is-fullwidth-code-point": "^1.0.0",
-                            "strip-ansi": "^3.0.0"
-                          },
-                          "dependencies": {
-                            "code-point-at": {
-                              "version": "1.1.0",
-                              "bundled": true
-                            },
-                            "is-fullwidth-code-point": {
-                              "version": "1.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "number-is-nan": "^1.0.0"
-                              },
-                              "dependencies": {
-                                "number-is-nan": {
-                                  "version": "1.0.1",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1",
-                          "bundled": true,
-                          "requires": {
-                            "ansi-regex": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.1.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "decamelize": {
-                  "version": "1.2.0",
-                  "bundled": true
-                },
-                "find-up": {
-                  "version": "2.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "locate-path": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "locate-path": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "p-locate": "^2.0.0",
-                        "path-exists": "^3.0.0"
-                      },
-                      "dependencies": {
-                        "p-locate": {
-                          "version": "2.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "p-limit": "^1.1.0"
-                          },
-                          "dependencies": {
-                            "p-limit": {
-                              "version": "1.2.0",
-                              "bundled": true,
-                              "requires": {
-                                "p-try": "^1.0.0"
-                              },
-                              "dependencies": {
-                                "p-try": {
-                                  "version": "1.0.0",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "path-exists": {
-                          "version": "3.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "get-caller-file": {
-                  "version": "1.0.2",
-                  "bundled": true
-                },
-                "os-locale": {
-                  "version": "2.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "execa": "^0.7.0",
-                    "lcid": "^1.0.0",
-                    "mem": "^1.1.0"
-                  },
-                  "dependencies": {
-                    "execa": {
-                      "version": "0.7.0",
-                      "bundled": true,
-                      "requires": {
-                        "cross-spawn": "^5.0.1",
-                        "get-stream": "^3.0.0",
-                        "is-stream": "^1.1.0",
-                        "npm-run-path": "^2.0.0",
-                        "p-finally": "^1.0.0",
-                        "signal-exit": "^3.0.0",
-                        "strip-eof": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "cross-spawn": {
-                          "version": "5.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "lru-cache": "^4.0.1",
-                            "shebang-command": "^1.2.0",
-                            "which": "^1.2.9"
-                          },
-                          "dependencies": {
-                            "shebang-command": {
-                              "version": "1.2.0",
-                              "bundled": true,
-                              "requires": {
-                                "shebang-regex": "^1.0.0"
-                              },
-                              "dependencies": {
-                                "shebang-regex": {
-                                  "version": "1.0.0",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "get-stream": {
-                          "version": "3.0.0",
-                          "bundled": true
-                        },
-                        "is-stream": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "npm-run-path": {
-                          "version": "2.0.2",
-                          "bundled": true,
-                          "requires": {
-                            "path-key": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "path-key": {
-                              "version": "2.0.1",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "p-finally": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "signal-exit": {
-                          "version": "3.0.2",
-                          "bundled": true
-                        },
-                        "strip-eof": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "lcid": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "invert-kv": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "invert-kv": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "mem": {
-                      "version": "1.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "mimic-fn": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "mimic-fn": {
-                          "version": "1.2.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "require-directory": {
-                  "version": "2.1.1",
-                  "bundled": true
-                },
-                "require-main-filename": {
-                  "version": "1.0.1",
-                  "bundled": true
-                },
-                "set-blocking": {
-                  "version": "2.0.0",
-                  "bundled": true
-                },
-                "string-width": {
-                  "version": "2.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "is-fullwidth-code-point": "^2.0.0",
-                    "strip-ansi": "^4.0.0"
-                  },
-                  "dependencies": {
-                    "is-fullwidth-code-point": {
-                      "version": "2.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "which-module": {
-                  "version": "2.0.0",
-                  "bundled": true
-                },
-                "y18n": {
-                  "version": "3.2.1",
-                  "bundled": true
-                },
-                "yargs-parser": {
-                  "version": "9.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "camelcase": "^4.1.0"
-                  },
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "4.1.0",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            }
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "lock-verify": {
-          "version": "2.0.2",
+          "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "npm-package-arg": "^5.1.2 || 6",
+            "npm-package-arg": "^6.1.0",
             "semver": "^5.4.1"
           }
         },
@@ -2657,12 +2417,6 @@
           "bundled": true,
           "requires": {
             "signal-exit": "^3.0.2"
-          },
-          "dependencies": {
-            "signal-exit": {
-              "version": "3.0.2",
-              "bundled": true
-            }
           }
         },
         "lodash._baseindexof": {
@@ -2675,16 +2429,6 @@
           "requires": {
             "lodash._createset": "~4.0.0",
             "lodash._root": "~3.0.0"
-          },
-          "dependencies": {
-            "lodash._createset": {
-              "version": "4.0.3",
-              "bundled": true
-            },
-            "lodash._root": {
-              "version": "3.0.1",
-              "bundled": true
-            }
           }
         },
         "lodash._bindcallback": {
@@ -2702,8 +2446,16 @@
             "lodash._getnative": "^3.0.0"
           }
         },
+        "lodash._createset": {
+          "version": "4.0.3",
+          "bundled": true
+        },
         "lodash._getnative": {
           "version": "3.9.1",
+          "bundled": true
+        },
+        "lodash._root": {
+          "version": "3.0.1",
           "bundled": true
         },
         "lodash.clonedeep": {
@@ -2726,27 +2478,98 @@
           "version": "4.4.0",
           "bundled": true
         },
+        "lowercase-keys": {
+          "version": "1.0.1",
+          "bundled": true
+        },
         "lru-cache": {
-          "version": "4.1.3",
+          "version": "5.1.1",
           "bundled": true,
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          },
-          "dependencies": {
-            "pseudomap": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "yallist": {
-              "version": "2.1.2",
-              "bundled": true
-            }
+            "yallist": "^3.0.2"
+          }
+        },
+        "make-dir": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "make-fetch-happen": {
+          "version": "4.0.2",
+          "bundled": true,
+          "requires": {
+            "agentkeepalive": "^3.4.1",
+            "cacache": "^11.3.3",
+            "http-cache-semantics": "^3.8.1",
+            "http-proxy-agent": "^2.1.0",
+            "https-proxy-agent": "^2.2.1",
+            "lru-cache": "^5.1.1",
+            "mississippi": "^3.0.0",
+            "node-fetch-npm": "^2.0.2",
+            "promise-retry": "^1.1.1",
+            "socks-proxy-agent": "^4.0.0",
+            "ssri": "^6.0.0"
           }
         },
         "meant": {
           "version": "1.0.1",
           "bundled": true
+        },
+        "mem": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "mime-db": {
+          "version": "1.35.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.19",
+          "bundled": true,
+          "requires": {
+            "mime-db": "~1.35.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "minipass": {
+          "version": "2.3.3",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          },
+          "dependencies": {
+            "yallist": {
+              "version": "3.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "minizlib": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
         },
         "mississippi": {
           "version": "3.0.0",
@@ -2762,132 +2585,6 @@
             "pumpify": "^1.3.3",
             "stream-each": "^1.1.0",
             "through2": "^2.0.0"
-          },
-          "dependencies": {
-            "concat-stream": {
-              "version": "1.6.1",
-              "bundled": true,
-              "requires": {
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
-              },
-              "dependencies": {
-                "typedarray": {
-                  "version": "0.0.6",
-                  "bundled": true
-                }
-              }
-            },
-            "duplexify": {
-              "version": "3.5.4",
-              "bundled": true,
-              "requires": {
-                "end-of-stream": "^1.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0",
-                "stream-shift": "^1.0.0"
-              },
-              "dependencies": {
-                "stream-shift": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "end-of-stream": {
-              "version": "1.4.1",
-              "bundled": true,
-              "requires": {
-                "once": "^1.4.0"
-              }
-            },
-            "flush-write-stream": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.4"
-              }
-            },
-            "from2": {
-              "version": "2.3.0",
-              "bundled": true,
-              "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0"
-              }
-            },
-            "parallel-transform": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "cyclist": "~0.2.2",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.1.5"
-              },
-              "dependencies": {
-                "cyclist": {
-                  "version": "0.2.2",
-                  "bundled": true
-                }
-              }
-            },
-            "pump": {
-              "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-              }
-            },
-            "pumpify": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "duplexify": "^3.5.3",
-                "inherits": "^2.0.3",
-                "pump": "^2.0.0"
-              },
-              "dependencies": {
-                "pump": {
-                  "version": "2.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "end-of-stream": "^1.1.0",
-                    "once": "^1.3.1"
-                  }
-                }
-              }
-            },
-            "stream-each": {
-              "version": "1.2.2",
-              "bundled": true,
-              "requires": {
-                "end-of-stream": "^1.1.0",
-                "stream-shift": "^1.0.0"
-              },
-              "dependencies": {
-                "stream-shift": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "through2": {
-              "version": "2.0.3",
-              "bundled": true,
-              "requires": {
-                "readable-stream": "^2.1.5",
-                "xtend": "~4.0.1"
-              },
-              "dependencies": {
-                "xtend": {
-                  "version": "4.0.1",
-                  "bundled": true
-                }
-              }
-            }
           }
         },
         "mkdirp": {
@@ -2895,12 +2592,6 @@
           "bundled": true,
           "requires": {
             "minimist": "0.0.8"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true
-            }
           }
         },
         "move-concurrently": {
@@ -2915,89 +2606,46 @@
             "run-queue": "^1.0.3"
           },
           "dependencies": {
-            "copy-concurrently": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "aproba": "^1.1.1",
-                "fs-write-stream-atomic": "^1.0.8",
-                "iferr": "^0.1.5",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.5.4",
-                "run-queue": "^1.0.0"
-              },
-              "dependencies": {
-                "iferr": {
-                  "version": "0.1.5",
-                  "bundled": true
-                }
-              }
-            },
-            "run-queue": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "aproba": "^1.1.1"
-              }
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true
             }
           }
         },
-        "node-gyp": {
-          "version": "3.6.2",
+        "ms": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "bundled": true
+        },
+        "node-fetch-npm": {
+          "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "fstream": "^1.0.0",
+            "encoding": "^0.1.11",
+            "json-parse-better-errors": "^1.0.0",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "node-gyp": {
+          "version": "5.0.2",
+          "bundled": true,
+          "requires": {
+            "env-paths": "^1.0.0",
             "glob": "^7.0.3",
             "graceful-fs": "^4.1.2",
-            "minimatch": "^3.0.2",
             "mkdirp": "^0.5.0",
             "nopt": "2 || 3",
             "npmlog": "0 || 1 || 2 || 3 || 4",
-            "osenv": "0",
-            "request": "2",
+            "request": "^2.87.0",
             "rimraf": "2",
             "semver": "~5.3.0",
-            "tar": "^2.0.0",
+            "tar": "^4.4.8",
             "which": "1"
           },
           "dependencies": {
-            "fstream": {
-              "version": "1.0.11",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
-              }
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.11",
-                  "bundled": true,
-                  "requires": {
-                    "balanced-match": "^1.0.0",
-                    "concat-map": "0.0.1"
-                  },
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
             "nopt": {
               "version": "3.0.6",
               "bundled": true,
@@ -3008,24 +2656,6 @@
             "semver": {
               "version": "5.3.0",
               "bundled": true
-            },
-            "tar": {
-              "version": "2.2.1",
-              "bundled": true,
-              "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
-              },
-              "dependencies": {
-                "block-stream": {
-                  "version": "0.0.9",
-                  "bundled": true,
-                  "requires": {
-                    "inherits": "~2.0.0"
-                  }
-                }
-              }
             }
           }
         },
@@ -3038,43 +2668,35 @@
           }
         },
         "normalize-package-data": {
-          "version": "2.4.0",
+          "version": "2.5.0",
           "bundled": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
-            "is-builtin-module": "^1.0.0",
+            "resolve": "^1.10.0",
             "semver": "2 || 3 || 4 || 5",
             "validate-npm-package-license": "^3.0.1"
           },
           "dependencies": {
-            "is-builtin-module": {
-              "version": "1.0.0",
+            "resolve": {
+              "version": "1.10.0",
               "bundled": true,
               "requires": {
-                "builtin-modules": "^1.0.0"
-              },
-              "dependencies": {
-                "builtin-modules": {
-                  "version": "1.1.1",
-                  "bundled": true
-                }
+                "path-parse": "^1.0.6"
               }
             }
           }
         },
         "npm-audit-report": {
-          "version": "1.2.1",
+          "version": "1.3.2",
           "bundled": true,
           "requires": {
-            "cli-table2": "^0.2.0",
+            "cli-table3": "^0.5.0",
             "console-control-strings": "^1.1.0"
-          },
-          "dependencies": {
-            "console-control-strings": {
-              "version": "1.1.0",
-              "bundled": true
-            }
           }
+        },
+        "npm-bundled": {
+          "version": "1.0.6",
+          "bundled": true
         },
         "npm-cache-filename": {
           "version": "1.0.2",
@@ -3088,28 +2710,22 @@
           }
         },
         "npm-lifecycle": {
-          "version": "2.0.3",
+          "version": "3.0.0",
           "bundled": true,
           "requires": {
             "byline": "^5.0.0",
-            "graceful-fs": "^4.1.11",
-            "node-gyp": "^3.6.2",
+            "graceful-fs": "^4.1.15",
+            "node-gyp": "^5.0.2",
             "resolve-from": "^4.0.0",
             "slide": "^1.1.6",
             "uid-number": "0.0.6",
             "umask": "^1.1.0",
-            "which": "^1.3.0"
-          },
-          "dependencies": {
-            "byline": {
-              "version": "5.0.0",
-              "bundled": true
-            },
-            "resolve-from": {
-              "version": "4.0.0",
-              "bundled": true
-            }
+            "which": "^1.3.1"
           }
+        },
+        "npm-logical-tree": {
+          "version": "1.2.1",
+          "bundled": true
         },
         "npm-package-arg": {
           "version": "6.1.0",
@@ -3122,1082 +2738,67 @@
           }
         },
         "npm-packlist": {
-          "version": "1.1.10",
+          "version": "1.4.4",
           "bundled": true,
           "requires": {
             "ignore-walk": "^3.0.1",
             "npm-bundled": "^1.0.1"
-          },
-          "dependencies": {
-            "ignore-walk": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "minimatch": "^3.0.4"
-              },
-              "dependencies": {
-                "minimatch": {
-                  "version": "3.0.4",
-                  "bundled": true,
-                  "requires": {
-                    "brace-expansion": "^1.1.7"
-                  },
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.8",
-                      "bundled": true,
-                      "requires": {
-                        "balanced-match": "^1.0.0",
-                        "concat-map": "0.0.1"
-                      },
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "npm-bundled": {
-              "version": "1.0.3",
-              "bundled": true
-            }
           }
         },
         "npm-pick-manifest": {
-          "version": "2.1.0",
+          "version": "2.2.3",
           "bundled": true,
           "requires": {
+            "figgy-pudding": "^3.5.1",
             "npm-package-arg": "^6.0.0",
             "semver": "^5.4.1"
           }
         },
         "npm-profile": {
-          "version": "3.0.1",
+          "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "aproba": "^1.1.2",
-            "make-fetch-happen": "^2.5.0"
-          },
-          "dependencies": {
-            "make-fetch-happen": {
-              "version": "2.6.0",
-              "bundled": true,
-              "requires": {
-                "agentkeepalive": "^3.3.0",
-                "cacache": "^10.0.0",
-                "http-cache-semantics": "^3.8.0",
-                "http-proxy-agent": "^2.0.0",
-                "https-proxy-agent": "^2.1.0",
-                "lru-cache": "^4.1.1",
-                "mississippi": "^1.2.0",
-                "node-fetch-npm": "^2.0.2",
-                "promise-retry": "^1.1.1",
-                "socks-proxy-agent": "^3.0.1",
-                "ssri": "^5.0.0"
-              },
-              "dependencies": {
-                "agentkeepalive": {
-                  "version": "3.3.0",
-                  "bundled": true,
-                  "requires": {
-                    "humanize-ms": "^1.2.1"
-                  },
-                  "dependencies": {
-                    "humanize-ms": {
-                      "version": "1.2.1",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.1.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "cacache": {
-                  "version": "10.0.4",
-                  "bundled": true,
-                  "requires": {
-                    "bluebird": "^3.5.1",
-                    "chownr": "^1.0.1",
-                    "glob": "^7.1.2",
-                    "graceful-fs": "^4.1.11",
-                    "lru-cache": "^4.1.1",
-                    "mississippi": "^2.0.0",
-                    "mkdirp": "^0.5.1",
-                    "move-concurrently": "^1.0.1",
-                    "promise-inflight": "^1.0.1",
-                    "rimraf": "^2.6.2",
-                    "ssri": "^5.2.4",
-                    "unique-filename": "^1.1.0",
-                    "y18n": "^4.0.0"
-                  },
-                  "dependencies": {
-                    "mississippi": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "concat-stream": "^1.5.0",
-                        "duplexify": "^3.4.2",
-                        "end-of-stream": "^1.1.0",
-                        "flush-write-stream": "^1.0.0",
-                        "from2": "^2.1.0",
-                        "parallel-transform": "^1.1.0",
-                        "pump": "^2.0.1",
-                        "pumpify": "^1.3.3",
-                        "stream-each": "^1.1.0",
-                        "through2": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "concat-stream": {
-                          "version": "1.6.2",
-                          "bundled": true,
-                          "requires": {
-                            "buffer-from": "^1.0.0",
-                            "inherits": "^2.0.3",
-                            "readable-stream": "^2.2.2",
-                            "typedarray": "^0.0.6"
-                          },
-                          "dependencies": {
-                            "buffer-from": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            },
-                            "typedarray": {
-                              "version": "0.0.6",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "duplexify": {
-                          "version": "3.5.4",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "^1.0.0",
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.0",
-                            "stream-shift": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "stream-shift": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "end-of-stream": {
-                          "version": "1.4.1",
-                          "bundled": true,
-                          "requires": {
-                            "once": "^1.4.0"
-                          }
-                        },
-                        "flush-write-stream": {
-                          "version": "1.0.3",
-                          "bundled": true,
-                          "requires": {
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.4"
-                          }
-                        },
-                        "from2": {
-                          "version": "2.3.0",
-                          "bundled": true,
-                          "requires": {
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.0"
-                          }
-                        },
-                        "parallel-transform": {
-                          "version": "1.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "cyclist": "~0.2.2",
-                            "inherits": "^2.0.3",
-                            "readable-stream": "^2.1.5"
-                          },
-                          "dependencies": {
-                            "cyclist": {
-                              "version": "0.2.2",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "pump": {
-                          "version": "2.0.1",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "once": "^1.3.1"
-                          }
-                        },
-                        "pumpify": {
-                          "version": "1.4.0",
-                          "bundled": true,
-                          "requires": {
-                            "duplexify": "^3.5.3",
-                            "inherits": "^2.0.3",
-                            "pump": "^2.0.0"
-                          }
-                        },
-                        "stream-each": {
-                          "version": "1.2.2",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "stream-shift": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "stream-shift": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "through2": {
-                          "version": "2.0.3",
-                          "bundled": true,
-                          "requires": {
-                            "readable-stream": "^2.1.5",
-                            "xtend": "~4.0.1"
-                          },
-                          "dependencies": {
-                            "xtend": {
-                              "version": "4.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "y18n": {
-                      "version": "4.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "http-cache-semantics": {
-                  "version": "3.8.1",
-                  "bundled": true
-                },
-                "http-proxy-agent": {
-                  "version": "2.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "4",
-                    "debug": "3.1.0"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "^5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "^4.0.3"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "debug": {
-                      "version": "3.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "https-proxy-agent": {
-                  "version": "2.2.1",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "^4.1.0",
-                    "debug": "^3.1.0"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "^5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "^4.0.3"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "debug": {
-                      "version": "3.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "mississippi": {
-                  "version": "1.3.1",
-                  "bundled": true,
-                  "requires": {
-                    "concat-stream": "^1.5.0",
-                    "duplexify": "^3.4.2",
-                    "end-of-stream": "^1.1.0",
-                    "flush-write-stream": "^1.0.0",
-                    "from2": "^2.1.0",
-                    "parallel-transform": "^1.1.0",
-                    "pump": "^1.0.0",
-                    "pumpify": "^1.3.3",
-                    "stream-each": "^1.1.0",
-                    "through2": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "concat-stream": {
-                      "version": "1.6.0",
-                      "bundled": true,
-                      "requires": {
-                        "inherits": "^2.0.3",
-                        "readable-stream": "^2.2.2",
-                        "typedarray": "^0.0.6"
-                      },
-                      "dependencies": {
-                        "typedarray": {
-                          "version": "0.0.6",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "duplexify": {
-                      "version": "3.5.3",
-                      "bundled": true,
-                      "requires": {
-                        "end-of-stream": "^1.0.0",
-                        "inherits": "^2.0.1",
-                        "readable-stream": "^2.0.0",
-                        "stream-shift": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "stream-shift": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "end-of-stream": {
-                      "version": "1.4.1",
-                      "bundled": true,
-                      "requires": {
-                        "once": "^1.4.0"
-                      }
-                    },
-                    "flush-write-stream": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "requires": {
-                        "inherits": "^2.0.1",
-                        "readable-stream": "^2.0.4"
-                      }
-                    },
-                    "from2": {
-                      "version": "2.3.0",
-                      "bundled": true,
-                      "requires": {
-                        "inherits": "^2.0.1",
-                        "readable-stream": "^2.0.0"
-                      }
-                    },
-                    "parallel-transform": {
-                      "version": "1.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "cyclist": "~0.2.2",
-                        "inherits": "^2.0.3",
-                        "readable-stream": "^2.1.5"
-                      },
-                      "dependencies": {
-                        "cyclist": {
-                          "version": "0.2.2",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "pump": {
-                      "version": "1.0.3",
-                      "bundled": true,
-                      "requires": {
-                        "end-of-stream": "^1.1.0",
-                        "once": "^1.3.1"
-                      }
-                    },
-                    "pumpify": {
-                      "version": "1.4.0",
-                      "bundled": true,
-                      "requires": {
-                        "duplexify": "^3.5.3",
-                        "inherits": "^2.0.3",
-                        "pump": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "pump": {
-                          "version": "2.0.1",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "once": "^1.3.1"
-                          }
-                        }
-                      }
-                    },
-                    "stream-each": {
-                      "version": "1.2.2",
-                      "bundled": true,
-                      "requires": {
-                        "end-of-stream": "^1.1.0",
-                        "stream-shift": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "stream-shift": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "through2": {
-                      "version": "2.0.3",
-                      "bundled": true,
-                      "requires": {
-                        "readable-stream": "^2.1.5",
-                        "xtend": "~4.0.1"
-                      },
-                      "dependencies": {
-                        "xtend": {
-                          "version": "4.0.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "node-fetch-npm": {
-                  "version": "2.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "encoding": "^0.1.11",
-                    "json-parse-better-errors": "^1.0.0",
-                    "safe-buffer": "^5.1.1"
-                  },
-                  "dependencies": {
-                    "encoding": {
-                      "version": "0.1.12",
-                      "bundled": true,
-                      "requires": {
-                        "iconv-lite": "~0.4.13"
-                      },
-                      "dependencies": {
-                        "iconv-lite": {
-                          "version": "0.4.19",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "json-parse-better-errors": {
-                      "version": "1.0.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "promise-retry": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "err-code": "^1.0.0",
-                    "retry": "^0.10.0"
-                  },
-                  "dependencies": {
-                    "err-code": {
-                      "version": "1.1.2",
-                      "bundled": true
-                    },
-                    "retry": {
-                      "version": "0.10.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "socks-proxy-agent": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "^4.1.0",
-                    "socks": "^1.1.10"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "^5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "^4.0.3"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "socks": {
-                      "version": "1.1.10",
-                      "bundled": true,
-                      "requires": {
-                        "ip": "^1.1.4",
-                        "smart-buffer": "^1.0.13"
-                      },
-                      "dependencies": {
-                        "ip": {
-                          "version": "1.1.5",
-                          "bundled": true
-                        },
-                        "smart-buffer": {
-                          "version": "1.1.15",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "ssri": {
-                  "version": "5.3.0",
-                  "bundled": true,
-                  "requires": {
-                    "safe-buffer": "^5.1.1"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "npm-registry-client": {
-          "version": "8.5.1",
-          "bundled": true,
-          "requires": {
-            "concat-stream": "^1.5.2",
-            "graceful-fs": "^4.1.6",
-            "normalize-package-data": "~1.0.1 || ^2.0.0",
-            "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
-            "npmlog": "2 || ^3.1.0 || ^4.0.0",
-            "once": "^1.3.3",
-            "request": "^2.74.0",
-            "retry": "^0.10.0",
-            "safe-buffer": "^5.1.1",
-            "semver": "2 >=2.2.1 || 3.x || 4 || 5",
-            "slide": "^1.1.3",
-            "ssri": "^5.2.4"
-          },
-          "dependencies": {
-            "concat-stream": {
-              "version": "1.6.1",
-              "bundled": true,
-              "requires": {
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
-              },
-              "dependencies": {
-                "typedarray": {
-                  "version": "0.0.6",
-                  "bundled": true
-                }
-              }
-            },
-            "retry": {
-              "version": "0.10.1",
-              "bundled": true
-            },
-            "ssri": {
-              "version": "5.3.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "^5.1.1"
-              }
-            }
+            "aproba": "^1.1.2 || 2",
+            "figgy-pudding": "^3.4.1",
+            "npm-registry-fetch": "^3.8.0"
           }
         },
         "npm-registry-fetch": {
-          "version": "1.1.0",
+          "version": "3.9.1",
           "bundled": true,
           "requires": {
+            "JSONStream": "^1.3.4",
             "bluebird": "^3.5.1",
-            "figgy-pudding": "^2.0.1",
-            "lru-cache": "^4.1.2",
-            "make-fetch-happen": "^3.0.0",
-            "npm-package-arg": "^6.0.0",
-            "safe-buffer": "^5.1.1"
+            "figgy-pudding": "^3.4.1",
+            "lru-cache": "^5.1.1",
+            "make-fetch-happen": "^4.0.2",
+            "npm-package-arg": "^6.1.0"
           },
           "dependencies": {
-            "figgy-pudding": {
-              "version": "2.0.1",
-              "bundled": true
-            },
             "make-fetch-happen": {
-              "version": "3.0.0",
+              "version": "4.0.2",
               "bundled": true,
               "requires": {
                 "agentkeepalive": "^3.4.1",
-                "cacache": "^10.0.4",
+                "cacache": "^11.3.3",
                 "http-cache-semantics": "^3.8.1",
                 "http-proxy-agent": "^2.1.0",
-                "https-proxy-agent": "^2.2.0",
-                "lru-cache": "^4.1.2",
+                "https-proxy-agent": "^2.2.1",
+                "lru-cache": "^5.1.1",
                 "mississippi": "^3.0.0",
                 "node-fetch-npm": "^2.0.2",
                 "promise-retry": "^1.1.1",
-                "socks-proxy-agent": "^3.0.1",
-                "ssri": "^5.2.4"
-              },
-              "dependencies": {
-                "agentkeepalive": {
-                  "version": "3.4.1",
-                  "bundled": true,
-                  "requires": {
-                    "humanize-ms": "^1.2.1"
-                  },
-                  "dependencies": {
-                    "humanize-ms": {
-                      "version": "1.2.1",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.1.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "cacache": {
-                  "version": "10.0.4",
-                  "bundled": true,
-                  "requires": {
-                    "bluebird": "^3.5.1",
-                    "chownr": "^1.0.1",
-                    "glob": "^7.1.2",
-                    "graceful-fs": "^4.1.11",
-                    "lru-cache": "^4.1.1",
-                    "mississippi": "^2.0.0",
-                    "mkdirp": "^0.5.1",
-                    "move-concurrently": "^1.0.1",
-                    "promise-inflight": "^1.0.1",
-                    "rimraf": "^2.6.2",
-                    "ssri": "^5.2.4",
-                    "unique-filename": "^1.1.0",
-                    "y18n": "^4.0.0"
-                  },
-                  "dependencies": {
-                    "mississippi": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "concat-stream": "^1.5.0",
-                        "duplexify": "^3.4.2",
-                        "end-of-stream": "^1.1.0",
-                        "flush-write-stream": "^1.0.0",
-                        "from2": "^2.1.0",
-                        "parallel-transform": "^1.1.0",
-                        "pump": "^2.0.1",
-                        "pumpify": "^1.3.3",
-                        "stream-each": "^1.1.0",
-                        "through2": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "concat-stream": {
-                          "version": "1.6.2",
-                          "bundled": true,
-                          "requires": {
-                            "buffer-from": "^1.0.0",
-                            "inherits": "^2.0.3",
-                            "readable-stream": "^2.2.2",
-                            "typedarray": "^0.0.6"
-                          },
-                          "dependencies": {
-                            "buffer-from": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            },
-                            "typedarray": {
-                              "version": "0.0.6",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "duplexify": {
-                          "version": "3.5.4",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "^1.0.0",
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.0",
-                            "stream-shift": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "stream-shift": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "end-of-stream": {
-                          "version": "1.4.1",
-                          "bundled": true,
-                          "requires": {
-                            "once": "^1.4.0"
-                          }
-                        },
-                        "flush-write-stream": {
-                          "version": "1.0.3",
-                          "bundled": true,
-                          "requires": {
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.4"
-                          }
-                        },
-                        "from2": {
-                          "version": "2.3.0",
-                          "bundled": true,
-                          "requires": {
-                            "inherits": "^2.0.1",
-                            "readable-stream": "^2.0.0"
-                          }
-                        },
-                        "parallel-transform": {
-                          "version": "1.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "cyclist": "~0.2.2",
-                            "inherits": "^2.0.3",
-                            "readable-stream": "^2.1.5"
-                          },
-                          "dependencies": {
-                            "cyclist": {
-                              "version": "0.2.2",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "pump": {
-                          "version": "2.0.1",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "once": "^1.3.1"
-                          }
-                        },
-                        "pumpify": {
-                          "version": "1.4.0",
-                          "bundled": true,
-                          "requires": {
-                            "duplexify": "^3.5.3",
-                            "inherits": "^2.0.3",
-                            "pump": "^2.0.0"
-                          }
-                        },
-                        "stream-each": {
-                          "version": "1.2.2",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "^1.1.0",
-                            "stream-shift": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "stream-shift": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "through2": {
-                          "version": "2.0.3",
-                          "bundled": true,
-                          "requires": {
-                            "readable-stream": "^2.1.5",
-                            "xtend": "~4.0.1"
-                          },
-                          "dependencies": {
-                            "xtend": {
-                              "version": "4.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "y18n": {
-                      "version": "4.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "http-cache-semantics": {
-                  "version": "3.8.1",
-                  "bundled": true
-                },
-                "http-proxy-agent": {
-                  "version": "2.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "4",
-                    "debug": "3.1.0"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "^5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "^4.0.3"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "debug": {
-                      "version": "3.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "https-proxy-agent": {
-                  "version": "2.2.1",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "^4.1.0",
-                    "debug": "^3.1.0"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "^5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "^4.0.3"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "debug": {
-                      "version": "3.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "node-fetch-npm": {
-                  "version": "2.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "encoding": "^0.1.11",
-                    "json-parse-better-errors": "^1.0.0",
-                    "safe-buffer": "^5.1.1"
-                  },
-                  "dependencies": {
-                    "encoding": {
-                      "version": "0.1.12",
-                      "bundled": true,
-                      "requires": {
-                        "iconv-lite": "~0.4.13"
-                      },
-                      "dependencies": {
-                        "iconv-lite": {
-                          "version": "0.4.21",
-                          "bundled": true,
-                          "requires": {
-                            "safer-buffer": "^2.1.0"
-                          },
-                          "dependencies": {
-                            "safer-buffer": {
-                              "version": "2.1.2",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "promise-retry": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "err-code": "^1.0.0",
-                    "retry": "^0.10.0"
-                  },
-                  "dependencies": {
-                    "err-code": {
-                      "version": "1.1.2",
-                      "bundled": true
-                    },
-                    "retry": {
-                      "version": "0.10.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "socks-proxy-agent": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "^4.1.0",
-                    "socks": "^1.1.10"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "^5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "^4.0.3"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "socks": {
-                      "version": "1.1.10",
-                      "bundled": true,
-                      "requires": {
-                        "ip": "^1.1.4",
-                        "smart-buffer": "^1.0.13"
-                      },
-                      "dependencies": {
-                        "ip": {
-                          "version": "1.1.5",
-                          "bundled": true
-                        },
-                        "smart-buffer": {
-                          "version": "1.1.15",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "ssri": {
-                  "version": "5.3.0",
-                  "bundled": true,
-                  "requires": {
-                    "safe-buffer": "^5.1.1"
-                  }
-                }
+                "socks-proxy-agent": "^4.0.0",
+                "ssri": "^6.0.0"
               }
             }
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "path-key": "^2.0.0"
           }
         },
         "npm-user-validate": {
@@ -4212,102 +2813,30 @@
             "console-control-strings": "~1.1.0",
             "gauge": "~2.7.3",
             "set-blocking": "~2.0.0"
-          },
-          "dependencies": {
-            "are-we-there-yet": {
-              "version": "1.1.4",
-              "bundled": true,
-              "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
-              },
-              "dependencies": {
-                "delegates": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "console-control-strings": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "gauge": {
-              "version": "2.7.4",
-              "bundled": true,
-              "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-              },
-              "dependencies": {
-                "object-assign": {
-                  "version": "4.1.1",
-                  "bundled": true
-                },
-                "signal-exit": {
-                  "version": "3.0.2",
-                  "bundled": true
-                },
-                "string-width": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "code-point-at": "^1.0.0",
-                    "is-fullwidth-code-point": "^1.0.0",
-                    "strip-ansi": "^3.0.0"
-                  },
-                  "dependencies": {
-                    "code-point-at": {
-                      "version": "1.1.0",
-                      "bundled": true
-                    },
-                    "is-fullwidth-code-point": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "number-is-nan": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "ansi-regex": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "wide-align": {
-                  "version": "1.1.2",
-                  "bundled": true,
-                  "requires": {
-                    "string-width": "^1.0.2"
-                  }
-                }
-              }
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "bundled": true
-            }
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "object-keys": {
+          "version": "1.0.12",
+          "bundled": true
+        },
+        "object.getownpropertydescriptors": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.5.1"
           }
         },
         "once": {
@@ -4318,7 +2847,24 @@
           }
         },
         "opener": {
-          "version": "1.4.3",
+          "version": "1.5.1",
+          "bundled": true
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
+          }
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
           "bundled": true
         },
         "osenv": {
@@ -4327,390 +2873,271 @@
           "requires": {
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
-          },
-          "dependencies": {
-            "os-homedir": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "os-tmpdir": {
-              "version": "1.0.2",
-              "bundled": true
-            }
+          }
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "p-limit": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "package-json": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "got": "^6.7.1",
+            "registry-auth-token": "^3.0.1",
+            "registry-url": "^3.0.3",
+            "semver": "^5.1.0"
           }
         },
         "pacote": {
-          "version": "8.1.5",
+          "version": "9.5.1",
           "bundled": true,
           "requires": {
-            "bluebird": "^3.5.1",
-            "cacache": "^11.0.2",
-            "get-stream": "^3.0.0",
-            "glob": "^7.1.2",
-            "lru-cache": "^4.1.3",
+            "bluebird": "^3.5.3",
+            "cacache": "^11.3.2",
+            "figgy-pudding": "^3.5.1",
+            "get-stream": "^4.1.0",
+            "glob": "^7.1.3",
+            "lru-cache": "^5.1.1",
             "make-fetch-happen": "^4.0.1",
             "minimatch": "^3.0.4",
-            "minipass": "^2.3.3",
+            "minipass": "^2.3.5",
             "mississippi": "^3.0.0",
             "mkdirp": "^0.5.1",
             "normalize-package-data": "^2.4.0",
             "npm-package-arg": "^6.1.0",
-            "npm-packlist": "^1.1.10",
-            "npm-pick-manifest": "^2.1.0",
+            "npm-packlist": "^1.1.12",
+            "npm-pick-manifest": "^2.2.3",
+            "npm-registry-fetch": "^3.8.0",
             "osenv": "^0.1.5",
             "promise-inflight": "^1.0.1",
             "promise-retry": "^1.1.1",
-            "protoduck": "^5.0.0",
+            "protoduck": "^5.0.1",
             "rimraf": "^2.6.2",
             "safe-buffer": "^5.1.2",
-            "semver": "^5.5.0",
-            "ssri": "^6.0.0",
-            "tar": "4.4.1",
-            "unique-filename": "^1.1.0",
-            "which": "^1.3.0"
+            "semver": "^5.6.0",
+            "ssri": "^6.0.1",
+            "tar": "^4.4.8",
+            "unique-filename": "^1.1.1",
+            "which": "^1.3.1"
           },
           "dependencies": {
-            "get-stream": {
-              "version": "3.0.0",
-              "bundled": true
-            },
-            "make-fetch-happen": {
-              "version": "4.0.1",
-              "bundled": true,
-              "requires": {
-                "agentkeepalive": "^3.4.1",
-                "cacache": "^11.0.1",
-                "http-cache-semantics": "^3.8.1",
-                "http-proxy-agent": "^2.1.0",
-                "https-proxy-agent": "^2.2.1",
-                "lru-cache": "^4.1.2",
-                "mississippi": "^3.0.0",
-                "node-fetch-npm": "^2.0.2",
-                "promise-retry": "^1.1.1",
-                "socks-proxy-agent": "^4.0.0",
-                "ssri": "^6.0.0"
-              },
-              "dependencies": {
-                "agentkeepalive": {
-                  "version": "3.4.1",
-                  "bundled": true,
-                  "requires": {
-                    "humanize-ms": "^1.2.1"
-                  },
-                  "dependencies": {
-                    "humanize-ms": {
-                      "version": "1.2.1",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.1.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "http-cache-semantics": {
-                  "version": "3.8.1",
-                  "bundled": true
-                },
-                "http-proxy-agent": {
-                  "version": "2.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "4",
-                    "debug": "3.1.0"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "^5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "^4.0.3"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "debug": {
-                      "version": "3.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "https-proxy-agent": {
-                  "version": "2.2.1",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "^4.1.0",
-                    "debug": "^3.1.0"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "^5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "^4.0.3"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "debug": {
-                      "version": "3.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "node-fetch-npm": {
-                  "version": "2.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "encoding": "^0.1.11",
-                    "json-parse-better-errors": "^1.0.0",
-                    "safe-buffer": "^5.1.1"
-                  },
-                  "dependencies": {
-                    "encoding": {
-                      "version": "0.1.12",
-                      "bundled": true,
-                      "requires": {
-                        "iconv-lite": "~0.4.13"
-                      },
-                      "dependencies": {
-                        "iconv-lite": {
-                          "version": "0.4.23",
-                          "bundled": true,
-                          "requires": {
-                            "safer-buffer": ">= 2.1.2 < 3"
-                          },
-                          "dependencies": {
-                            "safer-buffer": {
-                              "version": "2.1.2",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "socks-proxy-agent": {
-                  "version": "4.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "~4.2.0",
-                    "socks": "~2.2.0"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "^5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "^4.0.3"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "socks": {
-                      "version": "2.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "ip": "^1.1.5",
-                        "smart-buffer": "^4.0.1"
-                      },
-                      "dependencies": {
-                        "ip": {
-                          "version": "1.1.5",
-                          "bundled": true
-                        },
-                        "smart-buffer": {
-                          "version": "4.0.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.11",
-                  "bundled": true,
-                  "requires": {
-                    "balanced-match": "^1.0.0",
-                    "concat-map": "0.0.1"
-                  },
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
             "minipass": {
-              "version": "2.3.3",
+              "version": "2.3.5",
               "bundled": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
-              },
-              "dependencies": {
-                "yallist": {
-                  "version": "3.0.2",
-                  "bundled": true
-                }
-              }
-            },
-            "promise-retry": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "err-code": "^1.0.0",
-                "retry": "^0.10.0"
-              },
-              "dependencies": {
-                "err-code": {
-                  "version": "1.1.2",
-                  "bundled": true
-                },
-                "retry": {
-                  "version": "0.10.1",
-                  "bundled": true
-                }
-              }
-            },
-            "protoduck": {
-              "version": "5.0.0",
-              "bundled": true,
-              "requires": {
-                "genfun": "^4.0.1"
-              },
-              "dependencies": {
-                "genfun": {
-                  "version": "4.0.1",
-                  "bundled": true
-                }
               }
             }
           }
         },
+        "parallel-transform": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "cyclist": "~0.2.2",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.1.5"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
         "path-is-inside": {
           "version": "1.0.2",
+          "bundled": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "path-parse": {
+          "version": "1.0.6",
+          "bundled": true
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
           "bundled": true
         },
         "promise-inflight": {
           "version": "1.0.1",
           "bundled": true
         },
+        "promise-retry": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "err-code": "^1.0.0",
+            "retry": "^0.10.0"
+          },
+          "dependencies": {
+            "retry": {
+              "version": "0.10.1",
+              "bundled": true
+            }
+          }
+        },
+        "promzard": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "read": "1"
+          }
+        },
+        "proto-list": {
+          "version": "1.2.4",
+          "bundled": true
+        },
+        "protoduck": {
+          "version": "5.0.1",
+          "bundled": true,
+          "requires": {
+            "genfun": "^5.0.0"
+          }
+        },
+        "prr": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "psl": {
+          "version": "1.1.29",
+          "bundled": true
+        },
+        "pump": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "pumpify": {
+          "version": "1.5.1",
+          "bundled": true,
+          "requires": {
+            "duplexify": "^3.6.0",
+            "inherits": "^2.0.3",
+            "pump": "^2.0.0"
+          },
+          "dependencies": {
+            "pump": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+              }
+            }
+          }
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true
+        },
         "qrcode-terminal": {
           "version": "0.12.0",
           "bundled": true
         },
+        "qs": {
+          "version": "6.5.2",
+          "bundled": true
+        },
         "query-string": {
-          "version": "6.1.0",
+          "version": "6.8.1",
           "bundled": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
+            "split-on-first": "^1.0.0",
             "strict-uri-encode": "^2.0.0"
-          },
-          "dependencies": {
-            "decode-uri-component": {
-              "version": "0.2.0",
-              "bundled": true
-            },
-            "strict-uri-encode": {
-              "version": "2.0.0",
-              "bundled": true
-            }
           }
         },
         "qw": {
           "version": "1.0.1",
           "bundled": true
         },
+        "rc": {
+          "version": "1.2.7",
+          "bundled": true,
+          "requires": {
+            "deep-extend": "^0.5.1",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
         "read": {
           "version": "1.0.7",
           "bundled": true,
           "requires": {
             "mute-stream": "~0.0.4"
-          },
-          "dependencies": {
-            "mute-stream": {
-              "version": "0.0.7",
-              "bundled": true
-            }
           }
         },
         "read-cmd-shim": {
@@ -4731,12 +3158,6 @@
             "semver": "2 || 3 || 4 || 5",
             "slide": "~1.1.3",
             "util-extend": "^1.0.1"
-          },
-          "dependencies": {
-            "util-extend": {
-              "version": "1.0.3",
-              "bundled": true
-            }
           }
         },
         "read-package-json": {
@@ -4748,69 +3169,28 @@
             "json-parse-better-errors": "^1.0.1",
             "normalize-package-data": "^2.0.0",
             "slash": "^1.0.0"
-          },
-          "dependencies": {
-            "json-parse-better-errors": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "slash": {
-              "version": "1.0.0",
-              "bundled": true
-            }
           }
         },
         "read-package-tree": {
-          "version": "5.2.1",
+          "version": "5.3.1",
           "bundled": true,
           "requires": {
-            "debuglog": "^1.0.1",
-            "dezalgo": "^1.0.0",
-            "once": "^1.3.0",
             "read-package-json": "^2.0.0",
-            "readdir-scoped-modules": "^1.0.0"
+            "readdir-scoped-modules": "^1.0.0",
+            "util-promisify": "^2.1.0"
           }
         },
         "readable-stream": {
-          "version": "2.3.6",
+          "version": "3.4.0",
           "bundled": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          },
-          "dependencies": {
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "process-nextick-args": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "bundled": true
-            }
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         },
         "readdir-scoped-modules": {
-          "version": "1.0.2",
+          "version": "1.1.0",
           "bundled": true,
           "requires": {
             "debuglog": "^1.0.1",
@@ -4819,368 +3199,155 @@
             "once": "^1.3.0"
           }
         },
+        "registry-auth-token": {
+          "version": "3.3.2",
+          "bundled": true,
+          "requires": {
+            "rc": "^1.1.6",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "registry-url": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "rc": "^1.0.1"
+          }
+        },
         "request": {
-          "version": "2.86.0",
+          "version": "2.88.0",
           "bundled": true,
           "requires": {
             "aws-sign2": "~0.7.0",
-            "aws4": "^1.6.0",
+            "aws4": "^1.8.0",
             "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.1",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
             "forever-agent": "~0.6.1",
-            "form-data": "~2.3.1",
-            "har-validator": "~5.0.3",
-            "hawk": "~6.0.2",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
             "http-signature": "~1.2.0",
             "is-typedarray": "~1.0.0",
             "isstream": "~0.1.2",
             "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.17",
-            "oauth-sign": "~0.8.2",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
             "performance-now": "^2.1.0",
-            "qs": "~6.5.1",
-            "safe-buffer": "^5.1.1",
-            "tough-cookie": "~2.3.3",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
             "tunnel-agent": "^0.6.0",
-            "uuid": "^3.1.0"
-          },
-          "dependencies": {
-            "aws-sign2": {
-              "version": "0.7.0",
-              "bundled": true
-            },
-            "aws4": {
-              "version": "1.7.0",
-              "bundled": true
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true
-            },
-            "combined-stream": {
-              "version": "1.0.6",
-              "bundled": true,
-              "requires": {
-                "delayed-stream": "~1.0.0"
-              },
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true
-            },
-            "form-data": {
-              "version": "2.3.2",
-              "bundled": true,
-              "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "1.0.6",
-                "mime-types": "^2.1.12"
-              },
-              "dependencies": {
-                "asynckit": {
-                  "version": "0.4.0",
-                  "bundled": true
-                }
-              }
-            },
-            "har-validator": {
-              "version": "5.0.3",
-              "bundled": true,
-              "requires": {
-                "ajv": "^5.1.0",
-                "har-schema": "^2.0.0"
-              },
-              "dependencies": {
-                "ajv": {
-                  "version": "5.5.2",
-                  "bundled": true,
-                  "requires": {
-                    "co": "^4.6.0",
-                    "fast-deep-equal": "^1.0.0",
-                    "fast-json-stable-stringify": "^2.0.0",
-                    "json-schema-traverse": "^0.3.0"
-                  },
-                  "dependencies": {
-                    "co": {
-                      "version": "4.6.0",
-                      "bundled": true
-                    },
-                    "fast-deep-equal": {
-                      "version": "1.1.0",
-                      "bundled": true
-                    },
-                    "fast-json-stable-stringify": {
-                      "version": "2.0.0",
-                      "bundled": true
-                    },
-                    "json-schema-traverse": {
-                      "version": "0.3.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "har-schema": {
-                  "version": "2.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "hawk": {
-              "version": "6.0.2",
-              "bundled": true,
-              "requires": {
-                "boom": "4.x.x",
-                "cryptiles": "3.x.x",
-                "hoek": "4.x.x",
-                "sntp": "2.x.x"
-              },
-              "dependencies": {
-                "boom": {
-                  "version": "4.3.1",
-                  "bundled": true,
-                  "requires": {
-                    "hoek": "4.x.x"
-                  }
-                },
-                "cryptiles": {
-                  "version": "3.1.2",
-                  "bundled": true,
-                  "requires": {
-                    "boom": "5.x.x"
-                  },
-                  "dependencies": {
-                    "boom": {
-                      "version": "5.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "hoek": "4.x.x"
-                      }
-                    }
-                  }
-                },
-                "hoek": {
-                  "version": "4.2.1",
-                  "bundled": true
-                },
-                "sntp": {
-                  "version": "2.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "hoek": "4.x.x"
-                  }
-                }
-              }
-            },
-            "http-signature": {
-              "version": "1.2.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true
-                },
-                "jsprim": {
-                  "version": "1.4.1",
-                  "bundled": true,
-                  "requires": {
-                    "assert-plus": "1.0.0",
-                    "extsprintf": "1.3.0",
-                    "json-schema": "0.2.3",
-                    "verror": "1.10.0"
-                  },
-                  "dependencies": {
-                    "extsprintf": {
-                      "version": "1.3.0",
-                      "bundled": true
-                    },
-                    "json-schema": {
-                      "version": "0.2.3",
-                      "bundled": true
-                    },
-                    "verror": {
-                      "version": "1.10.0",
-                      "bundled": true,
-                      "requires": {
-                        "assert-plus": "^1.0.0",
-                        "core-util-is": "1.0.2",
-                        "extsprintf": "^1.2.0"
-                      },
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "sshpk": {
-                  "version": "1.14.1",
-                  "bundled": true,
-                  "requires": {
-                    "asn1": "~0.2.3",
-                    "assert-plus": "^1.0.0",
-                    "bcrypt-pbkdf": "^1.0.0",
-                    "dashdash": "^1.12.0",
-                    "ecc-jsbn": "~0.1.1",
-                    "getpass": "^0.1.1",
-                    "jsbn": "~0.1.0",
-                    "tweetnacl": "~0.14.0"
-                  },
-                  "dependencies": {
-                    "asn1": {
-                      "version": "0.2.3",
-                      "bundled": true
-                    },
-                    "bcrypt-pbkdf": {
-                      "version": "1.0.1",
-                      "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "tweetnacl": "^0.14.3"
-                      }
-                    },
-                    "dashdash": {
-                      "version": "1.14.1",
-                      "bundled": true,
-                      "requires": {
-                        "assert-plus": "^1.0.0"
-                      }
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "jsbn": "~0.1.0"
-                      }
-                    },
-                    "getpass": {
-                      "version": "0.1.7",
-                      "bundled": true,
-                      "requires": {
-                        "assert-plus": "^1.0.0"
-                      }
-                    },
-                    "jsbn": {
-                      "version": "0.1.1",
-                      "bundled": true,
-                      "optional": true
-                    },
-                    "tweetnacl": {
-                      "version": "0.14.5",
-                      "bundled": true,
-                      "optional": true
-                    }
-                  }
-                }
-              }
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "mime-types": {
-              "version": "2.1.18",
-              "bundled": true,
-              "requires": {
-                "mime-db": "~1.33.0"
-              },
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.33.0",
-                  "bundled": true
-                }
-              }
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "bundled": true
-            },
-            "performance-now": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "qs": {
-              "version": "6.5.2",
-              "bundled": true
-            },
-            "tough-cookie": {
-              "version": "2.3.4",
-              "bundled": true,
-              "requires": {
-                "punycode": "^1.4.1"
-              },
-              "dependencies": {
-                "punycode": {
-                  "version": "1.4.1",
-                  "bundled": true
-                }
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "^5.0.1"
-              }
-            }
+            "uuid": "^3.3.2"
           }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "bundled": true
         },
         "retry": {
           "version": "0.12.0",
           "bundled": true
         },
         "rimraf": {
-          "version": "2.6.2",
+          "version": "2.6.3",
           "bundled": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "^7.1.3"
+          }
+        },
+        "run-queue": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "aproba": "^1.1.1"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true
+            }
           }
         },
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true
         },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true
+        },
         "semver": {
-          "version": "5.5.0",
+          "version": "5.7.0",
+          "bundled": true
+        },
+        "semver-diff": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "semver": "^5.0.3"
+          }
+        },
+        "set-blocking": {
+          "version": "2.0.0",
           "bundled": true
         },
         "sha": {
-          "version": "2.0.1",
+          "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "readable-stream": "^2.0.2"
+            "graceful-fs": "^4.1.2"
           }
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "slash": {
+          "version": "1.0.0",
+          "bundled": true
         },
         "slide": {
           "version": "1.1.6",
           "bundled": true
+        },
+        "smart-buffer": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "socks": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "ip": "^1.1.5",
+            "smart-buffer": "^4.0.1"
+          }
+        },
+        "socks-proxy-agent": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "agent-base": "~4.2.0",
+            "socks": "~2.2.0"
+          }
         },
         "sorted-object": {
           "version": "2.0.1",
@@ -5200,114 +3367,284 @@
               "requires": {
                 "inherits": "~2.0.1",
                 "readable-stream": "~1.1.10"
-              },
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.1.14",
-                  "bundled": true,
-                  "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.1",
-                    "isarray": "0.0.1",
-                    "string_decoder": "~0.10.x"
-                  },
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "bundled": true
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "bundled": true
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "bundled": true
-                    }
-                  }
-                }
               }
             },
-            "stream-iterate": {
-              "version": "1.2.0",
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "readable-stream": {
+              "version": "1.1.14",
               "bundled": true,
               "requires": {
-                "readable-stream": "^2.1.5",
-                "stream-shift": "^1.0.0"
-              },
-              "dependencies": {
-                "stream-shift": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "bundled": true
+            }
+          }
+        },
+        "spdx-correct": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.3",
+          "bundled": true
+        },
+        "split-on-first": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "sshpk": {
+          "version": "1.14.2",
+          "bundled": true,
+          "requires": {
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.0.2",
+            "tweetnacl": "~0.14.0"
+          }
+        },
+        "ssri": {
+          "version": "6.0.1",
+          "bundled": true,
+          "requires": {
+            "figgy-pudding": "^3.5.1"
+          }
+        },
+        "stream-each": {
+          "version": "1.2.2",
+          "bundled": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "stream-iterate": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "^2.1.5",
+            "stream-shift": "^1.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
               }
             }
           }
         },
-        "ssri": {
-          "version": "6.0.0",
+        "stream-shift": {
+          "version": "1.0.0",
           "bundled": true
         },
-        "strip-ansi": {
-          "version": "4.0.0",
+        "strict-uri-encode": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "string-width": {
+          "version": "2.1.1",
           "bundled": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
               "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
             }
           }
         },
-        "tar": {
-          "version": "4.4.1",
+        "string_decoder": {
+          "version": "1.2.0",
           "bundled": true,
           "requires": {
-            "chownr": "^1.0.1",
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "stringify-package": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "bundled": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "tar": {
+          "version": "4.4.10",
+          "bundled": true,
+          "requires": {
+            "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
+            "minipass": "^2.3.5",
+            "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.2"
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.3"
           },
           "dependencies": {
-            "fs-minipass": {
-              "version": "1.2.5",
-              "bundled": true,
-              "requires": {
-                "minipass": "^2.2.1"
-              }
-            },
             "minipass": {
-              "version": "2.3.1",
+              "version": "2.3.5",
               "bundled": true,
               "requires": {
-                "safe-buffer": "^5.1.1",
+                "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
               }
             },
-            "minizlib": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "minipass": "^2.2.1"
-              }
-            },
             "yallist": {
-              "version": "3.0.2",
+              "version": "3.0.3",
               "bundled": true
             }
+          }
+        },
+        "term-size": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "execa": "^0.7.0"
           }
         },
         "text-table": {
           "version": "0.2.0",
           "bundled": true
         },
+        "through": {
+          "version": "2.3.8",
+          "bundled": true
+        },
+        "through2": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "timed-out": {
+          "version": "4.0.1",
+          "bundled": true
+        },
         "tiny-relative-date": {
           "version": "1.3.0",
+          "bundled": true
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "bundled": true,
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "typedarray": {
+          "version": "0.0.6",
           "bundled": true
         },
         "uid-number": {
@@ -5319,23 +3656,32 @@
           "bundled": true
         },
         "unique-filename": {
-          "version": "1.1.0",
+          "version": "1.1.1",
           "bundled": true,
           "requires": {
             "unique-slug": "^2.0.0"
-          },
-          "dependencies": {
-            "unique-slug": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "imurmurhash": "^0.1.4"
-              }
-            }
+          }
+        },
+        "unique-slug": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "imurmurhash": "^0.1.4"
+          }
+        },
+        "unique-string": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "crypto-random-string": "^1.0.0"
           }
         },
         "unpipe": {
           "version": "1.0.0",
+          "bundled": true
+        },
+        "unzip-response": {
+          "version": "2.0.1",
           "bundled": true
         },
         "update-notifier": {
@@ -5352,510 +3698,40 @@
             "latest-version": "^3.0.0",
             "semver-diff": "^2.0.0",
             "xdg-basedir": "^3.0.0"
-          },
-          "dependencies": {
-            "boxen": {
-              "version": "1.3.0",
-              "bundled": true,
-              "requires": {
-                "ansi-align": "^2.0.0",
-                "camelcase": "^4.0.0",
-                "chalk": "^2.0.1",
-                "cli-boxes": "^1.0.0",
-                "string-width": "^2.0.0",
-                "term-size": "^1.2.0",
-                "widest-line": "^2.0.0"
-              },
-              "dependencies": {
-                "ansi-align": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "string-width": "^2.0.0"
-                  }
-                },
-                "camelcase": {
-                  "version": "4.1.0",
-                  "bundled": true
-                },
-                "cli-boxes": {
-                  "version": "1.0.0",
-                  "bundled": true
-                },
-                "string-width": {
-                  "version": "2.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "is-fullwidth-code-point": "^2.0.0",
-                    "strip-ansi": "^4.0.0"
-                  },
-                  "dependencies": {
-                    "is-fullwidth-code-point": {
-                      "version": "2.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "term-size": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "requires": {
-                    "execa": "^0.7.0"
-                  },
-                  "dependencies": {
-                    "execa": {
-                      "version": "0.7.0",
-                      "bundled": true,
-                      "requires": {
-                        "cross-spawn": "^5.0.1",
-                        "get-stream": "^3.0.0",
-                        "is-stream": "^1.1.0",
-                        "npm-run-path": "^2.0.0",
-                        "p-finally": "^1.0.0",
-                        "signal-exit": "^3.0.0",
-                        "strip-eof": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "cross-spawn": {
-                          "version": "5.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "lru-cache": "^4.0.1",
-                            "shebang-command": "^1.2.0",
-                            "which": "^1.2.9"
-                          },
-                          "dependencies": {
-                            "shebang-command": {
-                              "version": "1.2.0",
-                              "bundled": true,
-                              "requires": {
-                                "shebang-regex": "^1.0.0"
-                              },
-                              "dependencies": {
-                                "shebang-regex": {
-                                  "version": "1.0.0",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "get-stream": {
-                          "version": "3.0.0",
-                          "bundled": true
-                        },
-                        "is-stream": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "npm-run-path": {
-                          "version": "2.0.2",
-                          "bundled": true,
-                          "requires": {
-                            "path-key": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "path-key": {
-                              "version": "2.0.1",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "p-finally": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "signal-exit": {
-                          "version": "3.0.2",
-                          "bundled": true
-                        },
-                        "strip-eof": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "widest-line": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "string-width": "^2.1.1"
-                  }
-                }
-              }
-            },
-            "chalk": {
-              "version": "2.4.1",
-              "bundled": true,
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              },
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "3.2.1",
-                  "bundled": true,
-                  "requires": {
-                    "color-convert": "^1.9.0"
-                  },
-                  "dependencies": {
-                    "color-convert": {
-                      "version": "1.9.1",
-                      "bundled": true,
-                      "requires": {
-                        "color-name": "^1.1.1"
-                      },
-                      "dependencies": {
-                        "color-name": {
-                          "version": "1.1.3",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "bundled": true
-                },
-                "supports-color": {
-                  "version": "5.4.0",
-                  "bundled": true,
-                  "requires": {
-                    "has-flag": "^3.0.0"
-                  },
-                  "dependencies": {
-                    "has-flag": {
-                      "version": "3.0.0",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "configstore": {
-              "version": "3.1.2",
-              "bundled": true,
-              "requires": {
-                "dot-prop": "^4.1.0",
-                "graceful-fs": "^4.1.2",
-                "make-dir": "^1.0.0",
-                "unique-string": "^1.0.0",
-                "write-file-atomic": "^2.0.0",
-                "xdg-basedir": "^3.0.0"
-              },
-              "dependencies": {
-                "dot-prop": {
-                  "version": "4.2.0",
-                  "bundled": true,
-                  "requires": {
-                    "is-obj": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "is-obj": {
-                      "version": "1.0.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "make-dir": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "requires": {
-                    "pify": "^3.0.0"
-                  },
-                  "dependencies": {
-                    "pify": {
-                      "version": "3.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "unique-string": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "crypto-random-string": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "crypto-random-string": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "import-lazy": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "is-ci": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "ci-info": "^1.0.0"
-              },
-              "dependencies": {
-                "ci-info": {
-                  "version": "1.1.3",
-                  "bundled": true
-                }
-              }
-            },
-            "is-installed-globally": {
-              "version": "0.1.0",
-              "bundled": true,
-              "requires": {
-                "global-dirs": "^0.1.0",
-                "is-path-inside": "^1.0.0"
-              },
-              "dependencies": {
-                "global-dirs": {
-                  "version": "0.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "ini": "^1.3.4"
-                  }
-                },
-                "is-path-inside": {
-                  "version": "1.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "path-is-inside": "^1.0.1"
-                  }
-                }
-              }
-            },
-            "is-npm": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "latest-version": {
-              "version": "3.1.0",
-              "bundled": true,
-              "requires": {
-                "package-json": "^4.0.0"
-              },
-              "dependencies": {
-                "package-json": {
-                  "version": "4.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "got": "^6.7.1",
-                    "registry-auth-token": "^3.0.1",
-                    "registry-url": "^3.0.3",
-                    "semver": "^5.1.0"
-                  },
-                  "dependencies": {
-                    "got": {
-                      "version": "6.7.1",
-                      "bundled": true,
-                      "requires": {
-                        "create-error-class": "^3.0.0",
-                        "duplexer3": "^0.1.4",
-                        "get-stream": "^3.0.0",
-                        "is-redirect": "^1.0.0",
-                        "is-retry-allowed": "^1.0.0",
-                        "is-stream": "^1.0.0",
-                        "lowercase-keys": "^1.0.0",
-                        "safe-buffer": "^5.0.1",
-                        "timed-out": "^4.0.0",
-                        "unzip-response": "^2.0.1",
-                        "url-parse-lax": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "create-error-class": {
-                          "version": "3.0.2",
-                          "bundled": true,
-                          "requires": {
-                            "capture-stack-trace": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "capture-stack-trace": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "duplexer3": {
-                          "version": "0.1.4",
-                          "bundled": true
-                        },
-                        "get-stream": {
-                          "version": "3.0.0",
-                          "bundled": true
-                        },
-                        "is-redirect": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "is-retry-allowed": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "is-stream": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "lowercase-keys": {
-                          "version": "1.0.1",
-                          "bundled": true
-                        },
-                        "timed-out": {
-                          "version": "4.0.1",
-                          "bundled": true
-                        },
-                        "unzip-response": {
-                          "version": "2.0.1",
-                          "bundled": true
-                        },
-                        "url-parse-lax": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "prepend-http": "^1.0.1"
-                          },
-                          "dependencies": {
-                            "prepend-http": {
-                              "version": "1.0.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "registry-auth-token": {
-                      "version": "3.3.2",
-                      "bundled": true,
-                      "requires": {
-                        "rc": "^1.1.6",
-                        "safe-buffer": "^5.0.1"
-                      },
-                      "dependencies": {
-                        "rc": {
-                          "version": "1.2.7",
-                          "bundled": true,
-                          "requires": {
-                            "deep-extend": "^0.5.1",
-                            "ini": "~1.3.0",
-                            "minimist": "^1.2.0",
-                            "strip-json-comments": "~2.0.1"
-                          },
-                          "dependencies": {
-                            "deep-extend": {
-                              "version": "0.5.1",
-                              "bundled": true
-                            },
-                            "minimist": {
-                              "version": "1.2.0",
-                              "bundled": true
-                            },
-                            "strip-json-comments": {
-                              "version": "2.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "registry-url": {
-                      "version": "3.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "rc": "^1.0.1"
-                      },
-                      "dependencies": {
-                        "rc": {
-                          "version": "1.2.7",
-                          "bundled": true,
-                          "requires": {
-                            "deep-extend": "^0.5.1",
-                            "ini": "~1.3.0",
-                            "minimist": "^1.2.0",
-                            "strip-json-comments": "~2.0.1"
-                          },
-                          "dependencies": {
-                            "deep-extend": {
-                              "version": "0.5.1",
-                              "bundled": true
-                            },
-                            "minimist": {
-                              "version": "1.2.0",
-                              "bundled": true
-                            },
-                            "strip-json-comments": {
-                              "version": "2.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "semver-diff": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "semver": "^5.0.3"
-              }
-            },
-            "xdg-basedir": {
-              "version": "3.0.0",
-              "bundled": true
-            }
+          }
+        },
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "prepend-http": "^1.0.1"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "util-extend": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "util-promisify": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "object.getownpropertydescriptors": "^2.0.3"
           }
         },
         "uuid": {
-          "version": "3.2.1",
+          "version": "3.3.2",
           "bundled": true
         },
         "validate-npm-package-license": {
-          "version": "3.0.3",
+          "version": "3.0.4",
           "bundled": true,
           "requires": {
             "spdx-correct": "^3.0.0",
             "spdx-expression-parse": "^3.0.0"
-          },
-          "dependencies": {
-            "spdx-correct": {
-              "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "spdx-expression-parse": "^3.0.0",
-                "spdx-license-ids": "^3.0.0"
-              },
-              "dependencies": {
-                "spdx-license-ids": {
-                  "version": "3.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "spdx-expression-parse": {
-              "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
-              },
-              "dependencies": {
-                "spdx-exceptions": {
-                  "version": "2.1.0",
-                  "bundled": true
-                },
-                "spdx-license-ids": {
-                  "version": "3.0.0",
-                  "bundled": true
-                }
-              }
-            }
           }
         },
         "validate-npm-package-name": {
@@ -5863,45 +3739,82 @@
           "bundled": true,
           "requires": {
             "builtins": "^1.0.3"
-          },
-          "dependencies": {
-            "builtins": {
-              "version": "1.0.3",
-              "bundled": true
-            }
+          }
+        },
+        "verror": {
+          "version": "1.10.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "^1.2.0"
+          }
+        },
+        "wcwidth": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "defaults": "^1.0.3"
           }
         },
         "which": {
-          "version": "1.3.0",
+          "version": "1.3.1",
           "bundled": true,
           "requires": {
             "isexe": "^2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "string-width": "^1.0.2"
           },
           "dependencies": {
-            "isexe": {
-              "version": "2.0.0",
-              "bundled": true
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
             }
           }
         },
+        "widest-line": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "^2.1.1"
+          }
+        },
         "worker-farm": {
-          "version": "1.6.0",
+          "version": "1.7.0",
           "bundled": true,
           "requires": {
             "errno": "~0.1.7"
+          }
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
           },
           "dependencies": {
-            "errno": {
-              "version": "0.1.7",
+            "string-width": {
+              "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "prr": "~1.0.1"
-              },
-              "dependencies": {
-                "prr": {
-                  "version": "1.0.1",
-                  "bundled": true
-                }
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -5911,18 +3824,59 @@
           "bundled": true
         },
         "write-file-atomic": {
-          "version": "2.3.0",
+          "version": "2.4.3",
           "bundled": true,
           "requires": {
             "graceful-fs": "^4.1.11",
             "imurmurhash": "^0.1.4",
             "signal-exit": "^3.0.2"
+          }
+        },
+        "xdg-basedir": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "bundled": true
+        },
+        "yargs": {
+          "version": "11.0.0",
+          "bundled": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
           },
           "dependencies": {
-            "signal-exit": {
-              "version": "3.0.2",
+            "y18n": {
+              "version": "3.2.1",
               "bundled": true
             }
+          }
+        },
+        "yargs-parser": {
+          "version": "9.0.2",
+          "bundled": true,
+          "requires": {
+            "camelcase": "^4.1.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "bugs:": "https://github.com/dnsimple/dnsimple-node/issues",
   "engines": {
-    "node": ">= v6.0.0"
+    "node": ">= v12.0.0"
   },
   "main": "lib/dnsimple.js",
   "files": [
@@ -36,7 +36,7 @@
     "nock": "^9.3.2"
   },
   "dependencies": {
-    "npm": "^6.1.0"
+    "npm": "^6.10.1"
   },
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dnsimple",
-  "version": "2.9.0",
+  "version": "3.0.0",
   "description": "A Node.JS client for the DNSimple API.",
   "keywords": [
     "dnsimple",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "bugs:": "https://github.com/dnsimple/dnsimple-node/issues",
   "engines": {
-    "node": ">= v12.0.0"
+    "node": ">= v8.0.0"
   },
   "main": "lib/dnsimple.js",
   "files": [


### PR DESCRIPTION
Updates Node to the current version and configures Travis to run a build for each supported Node version.

Because of the `lodash` vulnerability, we have to move to the latest maintenance Node. 

## 🔍 Verification

Travis builds are enough for this

## 🚀 Deploy

1. Create tag:
```
git tag -a v3.0.0 -s -m "Release 3.0.0"
git push origin --tags
```

2 . Run `npm publish` to push the new version out.