### PR TITLE
Release 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Release 3.0.1
+
+- Drops dependency on `npm`
+
 ### Release 3.0.0
 
 - NEW: Updates to support Node v8. Node v6 is deprecated.

--- a/lib/dnsimple.js
+++ b/lib/dnsimple.js
@@ -19,7 +19,7 @@ const services = {
   zones: require('./dnsimple/zones'),
 };
 
-Dnsimple.VERSION = '3.0.0';
+Dnsimple.VERSION = '3.0.1';
 Dnsimple.DEFAULT_TIMEOUT = require('http').createServer().timeout;
 Dnsimple.DEFAULT_BASE_URL = 'https://api.dnsimple.com';
 Dnsimple.DEFAULT_USER_AGENT = 'dnsimple-node/' + Dnsimple.VERSION;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dnsimple",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A Node.JS client for the DNSimple API.",
   "keywords": [
     "dnsimple",


### PR DESCRIPTION
Bump to 3.0.1. Dependency on `npm` has been removed.