### PR TITLE
Hardcode default timeout to 120000

### DIFF
--- a/lib/dnsimple.js
+++ b/lib/dnsimple.js
@@ -20,7 +20,7 @@ const services = {
 };
 
 Dnsimple.VERSION = '3.0.2';
-Dnsimple.DEFAULT_TIMEOUT = require('http').createServer().timeout;
+Dnsimple.DEFAULT_TIMEOUT = 120000;
 Dnsimple.DEFAULT_BASE_URL = 'https://api.dnsimple.com';
 Dnsimple.DEFAULT_USER_AGENT = 'dnsimple-node/' + Dnsimple.VERSION;
 Dnsimple.services = services;


### PR DESCRIPTION
In Node.js v13 this value has been changed to `0`. Hardcoding it to previous value will preserve behavior under Node.js v13

Closes #25 