### PR TITLE
Implements Semistandard (Moves out from JSCS)

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,9 +1,0 @@
-
-{
-  "preset": "node-style-guide",
-  "disallowKeywords": ["with"],
-  "maximumLineLength": { "value": 120 },
-  "requireSpread": false,
-  "requireTemplateStrings": false,
-  "requireCamelCaseOrUpperCaseIdentifiers": false
-}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 
 node_js:
-  - "8"
   - "10"
   - "12"
   - "13"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A Node.JS client for the [DNSimple API v2](https://developer.dnsimple.com/v2/).
 
 [![Build Status](https://travis-ci.com/dnsimple/dnsimple-node.svg?branch=master)](https://travis-ci.com/dnsimple/dnsimple-node)
 
+[![js-semistandard-style](https://img.shields.io/badge/code%20style-semistandard-brightgreen.svg?style=flat-square)](https://github.com/standard/semistandard)
 
 ## Requirements
 
@@ -21,7 +22,7 @@ Alternatively, install the latest stable version from NPM with `npm install dnsi
 
 This library is a nodejs client you can use to interact with the [DNSimple API v2](https://developer.dnsimple.com/v2/).
 
-Note that in all examples below, the `accessToken` must be an OAuth token as described in the [DNSimple API Access Token documentation](https://support.dnsimple.com/articles/api-access-token/). 
+Note that in all examples below, the `accessToken` must be an OAuth token as described in the [DNSimple API Access Token documentation](https://support.dnsimple.com/articles/api-access-token/).
 
 The DNSimple nodejs library uses promises exclusively, thus all client calls that call out to the DNSimple API will return a Promise. The examples below demonstrate basic usage.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Node.JS client for the [DNSimple API v2](https://developer.dnsimple.com/v2/).
 
 ## Requirements
 
-The dnsimple-node package requires node 8.0.0 or higher.
+The dnsimple-node package requires node 10.0.0 or higher.
 
 You must also have an activated DNSimple account to access the DNSimple API.
 

--- a/lib/dnsimple.js
+++ b/lib/dnsimple.js
@@ -16,7 +16,7 @@ const services = {
   tlds: require('./dnsimple/tlds'),
   vanityNameServers: require('./dnsimple/vanity_name_servers'),
   webhooks: require('./dnsimple/webhooks'),
-  zones: require('./dnsimple/zones'),
+  zones: require('./dnsimple/zones')
 };
 
 Dnsimple.VERSION = '3.0.3';
@@ -25,7 +25,7 @@ Dnsimple.DEFAULT_BASE_URL = 'https://api.dnsimple.com';
 Dnsimple.DEFAULT_USER_AGENT = 'dnsimple-node/' + Dnsimple.VERSION;
 Dnsimple.services = services;
 
-function Dnsimple(attrs) {
+function Dnsimple (attrs) {
   if (!(this instanceof Dnsimple)) {
     return new Dnsimple(attrs);
   }
@@ -33,7 +33,7 @@ function Dnsimple(attrs) {
   this._api = {
     accessToken: null,
     baseUrl: null,
-    userAgent: null,
+    userAgent: null
   };
 
   this.VERSION = Dnsimple.VERSION;
@@ -46,31 +46,31 @@ function Dnsimple(attrs) {
 }
 
 Dnsimple.prototype = {
-  setTimeout: function(timeout) {
+  setTimeout: function (timeout) {
     this.timeout = timeout || Dnsimple.DEFAULT_TIMEOUT;
   },
 
-  accessToken: function() {
+  accessToken: function () {
     return this._api.accessToken;
   },
 
-  setAccessToken: function(accessToken) {
+  setAccessToken: function (accessToken) {
     this._api.accessToken = accessToken;
   },
 
-  baseUrl: function() {
+  baseUrl: function () {
     return this._api.baseUrl;
   },
 
-  setBaseUrl: function(baseUrl) {
+  setBaseUrl: function (baseUrl) {
     this._api.baseUrl = url.parse(baseUrl || Dnsimple.DEFAULT_BASE_URL);
   },
 
-  userAgent: function() {
+  userAgent: function () {
     return this._api.userAgent;
   },
 
-  setUserAgent: function(userAgent) {
+  setUserAgent: function (userAgent) {
     if (!userAgent) {
       this._api.userAgent = Dnsimple.DEFAULT_USER_AGENT;
     } else {
@@ -78,11 +78,11 @@ Dnsimple.prototype = {
     }
   },
 
-  _setupServices: function() {
+  _setupServices: function () {
     for (var name in services) {
       this[name] = new services[name](this.client);
     }
-  },
-}
+  }
+};
 
 module.exports = Dnsimple;

--- a/lib/dnsimple.js
+++ b/lib/dnsimple.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const url = require('url');
 const Client = require('./dnsimple/client');
 const services = {
   accounts: require('./dnsimple/accounts'),
@@ -63,7 +62,7 @@ Dnsimple.prototype = {
   },
 
   setBaseUrl: function (baseUrl) {
-    this._api.baseUrl = url.parse(baseUrl || Dnsimple.DEFAULT_BASE_URL);
+    this._api.baseUrl = new URL(baseUrl || Dnsimple.DEFAULT_BASE_URL);
   },
 
   userAgent: function () {

--- a/lib/dnsimple/accounts.js
+++ b/lib/dnsimple/accounts.js
@@ -6,7 +6,7 @@
  * @see https://developer.dnsimple.com/v2/accounts
  */
 class Accounts {
-  constructor(client) {
+  constructor (client) {
     this._client = client;
   }
 
@@ -18,7 +18,7 @@ class Accounts {
    * @param {Object} [options]
    * @return {Promise}
    */
-  listAccounts(options = {}) {
+  listAccounts (options = {}) {
     return this._client.get('/accounts', options);
   }
 }

--- a/lib/dnsimple/certificates.js
+++ b/lib/dnsimple/certificates.js
@@ -8,7 +8,7 @@ const Paginate = require('./paginate');
  * @see https://developer.dnsimple.com/v2/domains/certificates
  */
 class Certificates {
-  constructor(client) {
+  constructor (client) {
     this._client = client;
   }
 
@@ -46,7 +46,7 @@ class Certificates {
    * @param {string} [options.sort] The sort definition in the form `key:direction`
    * @return {Promise}
    */
-  listCertificates(accountId, domainId, options = {}) {
+  listCertificates (accountId, domainId, options = {}) {
     return this._client.get(`/${accountId}/domains/${domainId}/certificates`, options);
   }
 
@@ -80,7 +80,7 @@ class Certificates {
    * @param {string} [options.sort] The sort definition in the form `key:direction`
    * @return {Promise}
    */
-  allCertificates(accountId, domainId, options = {}) {
+  allCertificates (accountId, domainId, options = {}) {
     return new Paginate(this).paginate(this.listCertificates, [accountId, domainId, options]);
   }
 
@@ -95,7 +95,7 @@ class Certificates {
    * @param {Object} [options]
    * @return {Promise}
    */
-  getCertificate(accountId, domainId, certificateId, options = {}) {
+  getCertificate (accountId, domainId, certificateId, options = {}) {
     return this._client.get(`/${accountId}/domains/${domainId}/certificates/${certificateId}`, options);
   }
 
@@ -110,7 +110,7 @@ class Certificates {
    * @param {Object} [options]
    * @return {Promise}
    */
-  downloadCertificate(accountId, domainId, certificateId, options = {}) {
+  downloadCertificate (accountId, domainId, certificateId, options = {}) {
     return this._client.get(`/${accountId}/domains/${domainId}/certificates/${certificateId}/download`, options);
   }
 
@@ -125,7 +125,7 @@ class Certificates {
    * @param {Object} [options]
    * @return {Promise}
    */
-  getCertificatePrivateKey(accountId, domainId, certificateId, options = {}) {
+  getCertificatePrivateKey (accountId, domainId, certificateId, options = {}) {
     return this._client.get(`/${accountId}/domains/${domainId}/certificates/${certificateId}/private_key`, options);
   }
 
@@ -143,7 +143,7 @@ class Certificates {
    * @param {Object} [options]
    * @return {Promise}
    */
-  purchaseLetsencryptCertificate(accountId, domainId, attributes, options = {}) {
+  purchaseLetsencryptCertificate (accountId, domainId, attributes, options = {}) {
     return this._client.post(`/${accountId}/domains/${domainId}/certificates/letsencrypt`, attributes, options);
   }
 
@@ -161,7 +161,7 @@ class Certificates {
    * @param {Object} [options]
    * @return {Promise}
    */
-  issueLetsencryptCertificate(accountId, domainId, certificatePurchaseId, options = {}) {
+  issueLetsencryptCertificate (accountId, domainId, certificatePurchaseId, options = {}) {
     return this._client.post(
       `/${accountId}/domains/${domainId}/certificates/letsencrypt/${certificatePurchaseId}/issue`, null, options);
   }
@@ -180,7 +180,7 @@ class Certificates {
    * @param {Object} [options]
    * @return {Promise}
    */
-  purchaseLetsencryptCertificateRenewal(accountId, domainId, certificateId, options = {}) {
+  purchaseLetsencryptCertificateRenewal (accountId, domainId, certificateId, options = {}) {
     return this._client.post(
       `/${accountId}/domains/${domainId}/certificates/letsencrypt/${certificateId}/renewal`, null, options);
   }
@@ -200,13 +200,12 @@ class Certificates {
    * @param {Object} [options]
    * @return {Promise}
    */
-  issueLetsencryptCertificateRenewal(accountId, domainId, oldCertificateId, certificateRenewalId, options = {}) {
+  issueLetsencryptCertificateRenewal (accountId, domainId, oldCertificateId, certificateRenewalId, options = {}) {
     return this._client.post(
       `/${accountId}/domains/${domainId}/certificates/` +
       `letsencrypt/${oldCertificateId}/renewals/${certificateRenewalId}/issue`,
       null, options);
   }
-
 }
 
 module.exports = Certificates;

--- a/lib/dnsimple/client.js
+++ b/lib/dnsimple/client.js
@@ -10,41 +10,41 @@ const querystring = require('querystring');
  * the calls to the DNSimple API.
  */
 class Client {
-  constructor(dnsimple) {
+  constructor (dnsimple) {
     this._dnsimple = dnsimple;
   }
 
-  baseUrl() {
+  baseUrl () {
     return this._dnsimple.baseUrl();
   }
 
-  get(path, options) {
+  get (path, options) {
     return this.request('GET', path, null, options);
   }
 
-  post(path, data, options) {
+  post (path, data, options) {
     return this.request('POST', path, data, options);
   }
 
-  put(path, data, options) {
+  put (path, data, options) {
     return this.request('PUT', path, data, options);
   }
 
-  patch(path, data, options) {
+  patch (path, data, options) {
     return this.request('PATCH', path, data, options);
   }
 
-  delete(path, options) {
+  delete (path, options) {
     return this.request('DELETE', path, null, options);
   }
 
-  request(method, path, data, options) {
+  request (method, path, data, options) {
     var timeout = this._dnsimple.timeout;
     var headers = {
       Authorization: `Bearer ${this._dnsimple.accessToken()}`,
       Accept: 'application/json',
       'Content-Type': 'application/json',
-      'User-Agent': this._dnsimple.userAgent(),
+      'User-Agent': this._dnsimple.userAgent()
     };
 
     var req = https.request({
@@ -52,14 +52,14 @@ class Client {
       port: this._dnsimple.baseUrl().port || 443,
       path: this._versionedPath(path, options),
       method: method,
-      headers: headers,
+      headers: headers
     });
 
     return new Promise((resolve, reject) => {
       req.setTimeout(timeout, this._timeoutHandler(timeout, req, reject));
       req.on('response', this._responseHandler(req, resolve, reject));
       req.on('error', this._errorHandler(req, reject));
-      req.on('socket', function(socket) {
+      req.on('socket', function (socket) {
         if (data != null) {
           req.write(JSON.stringify(data));
         }
@@ -68,38 +68,38 @@ class Client {
     });
   }
 
-  _timeoutHandler(timeout, req, reject) {
+  _timeoutHandler (timeout, req, reject) {
     return () => {
       req._isAborted = true;
       req.abort();
 
-      reject.call(this, {description: 'timeout'});
-    }
+      reject.call(this, { description: 'timeout' });
+    };
   }
 
-  _responseHandler(req, resolve, reject) {
+  _responseHandler (req, resolve, reject) {
     return (res) => {
       var data = '';
 
       res.setEncoding('utf8');
-      res.on('data', (chunk) => { data += chunk });
+      res.on('data', (chunk) => { data += chunk; });
       res.on('end', () => {
         try {
           if (res.statusCode == 401) {
             var error = JSON.parse(data);
-            error.description = 'Authentication error'
+            error.description = 'Authentication error';
             reject.call(this, error);
           } else if (res.statusCode == 404) {
             var error = JSON.parse(data);
-            error.description = 'Not found'
+            error.description = 'Not found';
             reject.call(this, error);
           } else if (res.statusCode == 405) {
-            reject.call(this, {description: 'Method not allowed'});
+            reject.call(this, { description: 'Method not allowed' });
           } else if (res.statusCode == 429) {
-            reject.call(this, {description: 'Too many requests'});
+            reject.call(this, { description: 'Too many requests' });
           } else if (res.statusCode >= 400 && res.statusCode < 500) {
             var error = JSON.parse(data);
-            error.description = 'Bad request'
+            error.description = 'Bad request';
             reject.call(this, error);
           } else if (res.statusCode == 204) {
             resolve.call(this, {});
@@ -114,40 +114,40 @@ class Client {
           reject.call(this, e.message);
         }
       });
-    }
+    };
   }
 
-  _errorHandler(req, reject) {
+  _errorHandler (req, reject) {
     return (error) => {
       if (!req._isAborted) {
         var errorObj = {
           description: 'An error occurred communicating with DNSimple API',
-          error: error,
+          error: error
         };
         reject.call(this, errorObj);
       }
-    }
+    };
   }
 
-  _versionedPath(path, options) {
+  _versionedPath (path, options) {
     var versionedPath = '/v2' + path;
     var query = {};
 
     if (!(typeof options.query === 'undefined')) {
-      for (let key in options.query) {
+      for (const key in options.query) {
         query[key] = options.query[key];
       }
       delete options.query;
     }
 
     if (!(typeof options.filter === 'undefined')) {
-      for (let key in options.filter) {
+      for (const key in options.filter) {
         query[key] = options.filter[key];
       }
       delete options.filter;
     }
 
-    for (let key in options) {
+    for (const key in options) {
       query[key] = options[key];
     }
 

--- a/lib/dnsimple/client.js
+++ b/lib/dnsimple/client.js
@@ -80,28 +80,29 @@ class Client {
   _responseHandler (req, resolve, reject) {
     return (res) => {
       var data = '';
+      var error;
 
       res.setEncoding('utf8');
       res.on('data', (chunk) => { data += chunk; });
       res.on('end', () => {
         try {
-          if (res.statusCode == 401) {
-            var error = JSON.parse(data);
+          if (res.statusCode === 401) {
+            error = JSON.parse(data);
             error.description = 'Authentication error';
             reject.call(this, error);
-          } else if (res.statusCode == 404) {
-            var error = JSON.parse(data);
+          } else if (res.statusCode === 404) {
+            error = JSON.parse(data);
             error.description = 'Not found';
             reject.call(this, error);
-          } else if (res.statusCode == 405) {
+          } else if (res.statusCode === 405) {
             reject.call(this, { description: 'Method not allowed' });
-          } else if (res.statusCode == 429) {
+          } else if (res.statusCode === 429) {
             reject.call(this, { description: 'Too many requests' });
           } else if (res.statusCode >= 400 && res.statusCode < 500) {
-            var error = JSON.parse(data);
+            error = JSON.parse(data);
             error.description = 'Bad request';
             reject.call(this, error);
-          } else if (res.statusCode == 204) {
+          } else if (res.statusCode === 204) {
             resolve.call(this, {});
           } else if (res.statusCode >= 200 && res.statusCode < 300) {
             resolve.call(this, JSON.parse(data));

--- a/lib/dnsimple/collaborators.js
+++ b/lib/dnsimple/collaborators.js
@@ -9,7 +9,7 @@ const Paginate = require('./paginate');
  * @deprecated Use domains.collaborators
  */
 class Collaborators {
-  constructor(client) {
+  constructor (client) {
     this._client = client;
   }
 
@@ -47,7 +47,7 @@ class Collaborators {
    * @param {string} [options.sort] The sort definition in the form `key:direction`
    * @return {Promise}
    */
-  listCollaborators(accountId, domainId, options = {}) {
+  listCollaborators (accountId, domainId, options = {}) {
     return this._client.get(`/${accountId}/domains/${domainId}/collaborators`, options);
   }
 
@@ -62,7 +62,7 @@ class Collaborators {
    * @param {Object} [options]
    * @return {Promise}
    */
-  addCollaborator(accountId, domainId, collaborator, options = {}) {
+  addCollaborator (accountId, domainId, collaborator, options = {}) {
     return this._client.post(`/${accountId}/domains/${domainId}/collaborators`, collaborator, options);
   }
 
@@ -77,7 +77,7 @@ class Collaborators {
    * @param {Object} [options]
    * @return {Promise}
    */
-  removeCollaborator(accountId, domainId, collaboratorId, options = {}) {
+  removeCollaborator (accountId, domainId, collaboratorId, options = {}) {
     return this._client.delete(`/${accountId}/domains/${domainId}/collaborators/${collaboratorId}`, options);
   }
 }

--- a/lib/dnsimple/collaborators.js
+++ b/lib/dnsimple/collaborators.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const Paginate = require('./paginate');
-
 /**
  * Provides access to the DNSimple Collaborators API.
  *

--- a/lib/dnsimple/contacts.js
+++ b/lib/dnsimple/contacts.js
@@ -8,7 +8,7 @@ const Paginate = require('./paginate');
  * @see https://developer.dnsimple.com/v2/contacts
  */
 class Contacts {
-  constructor(client) {
+  constructor (client) {
     this._client = client;
   }
 
@@ -45,7 +45,7 @@ class Contacts {
    * @param {string} [options.sort] The sort definition in the form `key:direction`
    * @return {Promise}
    */
-  listContacts(accountId, options = {}) {
+  listContacts (accountId, options = {}) {
     return this._client.get(`/${accountId}/contacts`, options);
   }
 
@@ -78,7 +78,7 @@ class Contacts {
    * @param {string} [options.sort] The sort definition in the form `key:direction`
    * @return {Promise}
    */
-  allContacts(accountId, options = {}) {
+  allContacts (accountId, options = {}) {
     return new Paginate(this).paginate(this.listContacts, [accountId, options]);
   }
 
@@ -92,7 +92,7 @@ class Contacts {
    * @param {Object} [options]
    * @return {Promise}
    */
-  getContact(accountId, contactId, options = {}) {
+  getContact (accountId, contactId, options = {}) {
     return this._client.get(`/${accountId}/contacts/${contactId}`, options);
   }
 
@@ -106,7 +106,7 @@ class Contacts {
    * @param {Object} [options]
    * @return {Promise}
    */
-  createContact(accountId, attributes, options = {}) {
+  createContact (accountId, attributes, options = {}) {
     return this._client.post(`/${accountId}/contacts`, attributes, options);
   }
 
@@ -121,7 +121,7 @@ class Contacts {
    * @param {Object} [options]
    * @return {Promise}
    */
-  updateContact(accountId, contactId, attributes, options = {}) {
+  updateContact (accountId, contactId, attributes, options = {}) {
     return this._client.patch(`/${accountId}/contacts/${contactId}`, attributes, options);
   }
 
@@ -135,7 +135,7 @@ class Contacts {
    * @param {Object} [options]
    * @return {Promise}
    */
-  deleteContact(accountId, contactId, options = {}) {
+  deleteContact (accountId, contactId, options = {}) {
     return this._client.delete(`/${accountId}/contacts/${contactId}`, options);
   }
 }

--- a/lib/dnsimple/domains.js
+++ b/lib/dnsimple/domains.js
@@ -8,7 +8,7 @@ const Paginate = require('./paginate');
  * @see https://developer.dnsimple.com/v2/domains
  */
 class Domains {
-  constructor(client) {
+  constructor (client) {
     this._client = client;
   }
 
@@ -54,7 +54,7 @@ class Domains {
    * @param {string} [options.registrant_id] Filter only domains with the given registrant ID
    * @return {Promise}
    */
-  listDomains(accountId, options = {}) {
+  listDomains (accountId, options = {}) {
     return this._client.get(`/${accountId}/domains`, options);
   }
 
@@ -96,7 +96,7 @@ class Domains {
    * @param {string} [options.registrant_id] Filter only domains with the given registrant ID
    * @return {Promise}
    */
-  allDomains(accountId, options = {}) {
+  allDomains (accountId, options = {}) {
     return new Paginate(this).paginate(this.listDomains, [accountId, options]);
   }
 
@@ -110,7 +110,7 @@ class Domains {
    * @param {Object} [options]
    * @return {Promise}
    */
-  getDomain(accountId, domainId, options = {}) {
+  getDomain (accountId, domainId, options = {}) {
     return this._client.get(`/${accountId}/domains/${domainId}`, options);
   }
 
@@ -124,7 +124,7 @@ class Domains {
    * @param {Object} [options]
    * @return {Promise}
    */
-  createDomain(accountId, attributes, options = {}) {
+  createDomain (accountId, attributes, options = {}) {
     return this._client.post(`/${accountId}/domains`, attributes, options);
   }
 
@@ -140,7 +140,7 @@ class Domains {
    * @param {Object} [options]
    * @return {Promise}
    */
-  deleteDomain(accountId, domainId, options = {}) {
+  deleteDomain (accountId, domainId, options = {}) {
     return this._client.delete(`/${accountId}/domains/${domainId}`, options);
   }
 
@@ -154,7 +154,7 @@ class Domains {
    * @param {Object} [options]
    * @return {Promise}
    */
-  resetDomainToken(accountId, domainId, options = {}) {
+  resetDomainToken (accountId, domainId, options = {}) {
     return this._client.post(`/${accountId}/domains/${domainId}/token`, null, options);
   }
 
@@ -192,7 +192,7 @@ class Domains {
    * @param {string} [options.sort] The sort definition in the form `key:direction`
    * @return {Promise}
    */
-  listCollaborators(accountId, domainId, options = {}) {
+  listCollaborators (accountId, domainId, options = {}) {
     return this._client.get(`/${accountId}/domains/${domainId}/collaborators`, options);
   }
 
@@ -207,7 +207,7 @@ class Domains {
    * @param {Object} [options]
    * @return {Promise}
    */
-  addCollaborator(accountId, domainId, collaborator, options = {}) {
+  addCollaborator (accountId, domainId, collaborator, options = {}) {
     return this._client.post(`/${accountId}/domains/${domainId}/collaborators`, collaborator, options);
   }
 
@@ -222,7 +222,7 @@ class Domains {
    * @param {Object} [options]
    * @return {Promise}
    */
-  removeCollaborator(accountId, domainId, collaboratorId, options = {}) {
+  removeCollaborator (accountId, domainId, collaboratorId, options = {}) {
     return this._client.delete(`/${accountId}/domains/${domainId}/collaborators/${collaboratorId}`, options);
   }
 
@@ -236,7 +236,7 @@ class Domains {
    * @param {Object} [options]
    * @return {Promise}
    */
-  enableDnssec(accountId, domainId, options = {}) {
+  enableDnssec (accountId, domainId, options = {}) {
     return this._client.post(`/${accountId}/domains/${domainId}/dnssec`, null, options);
   }
 
@@ -250,7 +250,7 @@ class Domains {
    * @param {Object} [options]
    * @return {Promise}
    */
-  disableDnssec(accountId, domainId, options = {}) {
+  disableDnssec (accountId, domainId, options = {}) {
     return this._client.delete(`/${accountId}/domains/${domainId}/dnssec`, options);
   }
 
@@ -264,7 +264,7 @@ class Domains {
    * @param {Object} [options]
    * @return {Promise}
    */
-  getDnssec(accountId, domainId, options = {}) {
+  getDnssec (accountId, domainId, options = {}) {
     return this._client.get(`/${accountId}/domains/${domainId}/dnssec`, options);
   }
 
@@ -302,7 +302,7 @@ class Domains {
    * @param {string} [options.sort] The sort definition in the form `key:direction`
    * @return {Promise}
    */
-  listDelegationSignerRecords(accountId, domainId, options = {}) {
+  listDelegationSignerRecords (accountId, domainId, options = {}) {
     return this._client.get(`/${accountId}/domains/${domainId}/ds_records`, options);
   }
 
@@ -336,7 +336,7 @@ class Domains {
    * @param {string} [options.sort] The sort definition in the form `key:direction`
    * @return {Promise}
    */
-  allDelegationSignerRecords(accountId, domainId, options = {}) {
+  allDelegationSignerRecords (accountId, domainId, options = {}) {
     return new Paginate(this).paginate(this.listDelegationSignerRecords, [accountId, domainId, options]);
   }
 
@@ -352,7 +352,7 @@ class Domains {
    * @param {Object} [options]
    * @return {Promise}
    */
-  getDelegationSignerRecord(accountId, domainId, delegationSignerRecordId, options = {}) {
+  getDelegationSignerRecord (accountId, domainId, delegationSignerRecordId, options = {}) {
     return this._client.get(`/${accountId}/domains/${domainId}/ds_records/${delegationSignerRecordId}`, options);
   }
 
@@ -367,7 +367,7 @@ class Domains {
    * @param {Object} [options]
    * @return {Promise}
    */
-  createDelegationSignerRecord(accountId, domainId, attributes, options = {}) {
+  createDelegationSignerRecord (accountId, domainId, attributes, options = {}) {
     return this._client.post(`/${accountId}/domains/${domainId}/ds_records`, attributes, options);
   }
 
@@ -383,7 +383,7 @@ class Domains {
    * @param {Object} [options]
    * @return {Promise}
    */
-  deleteDelegationSignerRecord(accountId, domainId, delegationSignerRecordId, options = {}) {
+  deleteDelegationSignerRecord (accountId, domainId, delegationSignerRecordId, options = {}) {
     return this._client.delete(`/${accountId}/domains/${domainId}/ds_records/${delegationSignerRecordId}`, options);
   }
 
@@ -421,7 +421,7 @@ class Domains {
    * @param {string} [options.sort] The sort definition in the form `key:direction`
    * @return {Promise}
    */
-  listEmailForwards(accountId, domainId, options = {}) {
+  listEmailForwards (accountId, domainId, options = {}) {
     return this._client.get(`/${accountId}/domains/${domainId}/email_forwards`, options);
   }
 
@@ -455,7 +455,7 @@ class Domains {
    * @param {string} [options.sort] The sort definition in the form `key:direction`
    * @return {Promise}
    */
-  allEmailForwards(accountId, domainId, options = {}) {
+  allEmailForwards (accountId, domainId, options = {}) {
     return new Paginate(this).paginate(this.listEmailForwards, [accountId, domainId, options]);
   }
 
@@ -470,7 +470,7 @@ class Domains {
    * @param {Object} [options]
    * @return {Promise}
    */
-  getEmailForward(accountId, domainId, emailForwardId, options = {}) {
+  getEmailForward (accountId, domainId, emailForwardId, options = {}) {
     return this._client.get(`/${accountId}/domains/${domainId}/email_forwards/${emailForwardId}`, options);
   }
 
@@ -485,7 +485,7 @@ class Domains {
    * @param {Object} [options]
    * @return {Promise}
    */
-  createEmailForward(accountId, domainId, attributes, options = {}) {
+  createEmailForward (accountId, domainId, attributes, options = {}) {
     return this._client.post(`/${accountId}/domains/${domainId}/email_forwards`, attributes, options);
   }
 
@@ -500,7 +500,7 @@ class Domains {
    * @param {Object} [options]
    * @return {Promise}
    */
-  deleteEmailForward(accountId, domainId, emailForwardId, options = {}) {
+  deleteEmailForward (accountId, domainId, emailForwardId, options = {}) {
     return this._client.delete(`/${accountId}/domains/${domainId}/email_forwards/${emailForwardId}`, options);
   }
 
@@ -517,7 +517,7 @@ class Domains {
    * @param {Object} [options]
    * @return {Promise}
    */
-  initiatePush(accountId, domainId, attributes, options = {}) {
+  initiatePush (accountId, domainId, attributes, options = {}) {
     return this._client.post(`/${accountId}/domains/${domainId}/pushes`, attributes, options);
   }
 
@@ -530,7 +530,7 @@ class Domains {
    * @param {Object} [options]
    * @return {Promise}
    */
-  listPushes(accountId, options = {}) {
+  listPushes (accountId, options = {}) {
     return this._client.get(`/${accountId}/pushes`, options);
   }
 
@@ -546,7 +546,7 @@ class Domains {
    * @param {Object} [options]
    * @return {Promise}
    */
-  acceptPush(accountId, pushId, attributes, options = {}) {
+  acceptPush (accountId, pushId, attributes, options = {}) {
     return this._client.post(`/${accountId}/pushes/${pushId}`, attributes, options);
   }
 
@@ -560,7 +560,7 @@ class Domains {
    * @param {Object} [options]
    * @return {Promise}
    */
-  rejectPush(accountId, pushId, options = {}) {
+  rejectPush (accountId, pushId, options = {}) {
     return this._client.delete(`/${accountId}/pushes/${pushId}`, options);
   }
 }

--- a/lib/dnsimple/identity.js
+++ b/lib/dnsimple/identity.js
@@ -6,7 +6,7 @@
  * @see https://developer.dnsimple.com/v2/identity
  */
 class Identity {
-  constructor(client) {
+  constructor (client) {
     this._client = client;
   }
 
@@ -18,7 +18,7 @@ class Identity {
    * @param {Object} [options]
    * @return {Promise}
    */
-  whoami(options = {}) {
+  whoami (options = {}) {
     return this._client.get('/whoami', options);
   }
 }

--- a/lib/dnsimple/oauth.js
+++ b/lib/dnsimple/oauth.js
@@ -8,7 +8,7 @@ const querystring = require('querystring');
  * @see https://developer.dnsimple.com/v2/oauth
  */
 class Oauth {
-  constructor(client) {
+  constructor (client) {
     this._client = client;
   }
 
@@ -25,13 +25,13 @@ class Oauth {
    * @param {string} [options.redirectUri] A redirect URI
    * @return {Promise}
    */
-  exchangeAuthorizationForToken(code, clientId, clientSecret, options = {}) {
-    let attributes = {
+  exchangeAuthorizationForToken (code, clientId, clientSecret, options = {}) {
+    const attributes = {
       code: code,
       client_id: clientId,
       client_secret: clientSecret,
-      grant_type: 'authorization_code',
-    }
+      grant_type: 'authorization_code'
+    };
 
     if (!(options.state === undefined)) {
       attributes.state = options.state;
@@ -43,7 +43,7 @@ class Oauth {
       delete options.redirectUri;
     }
 
-    return this._client.post('/oauth/access_token', attributes, options)
+    return this._client.post('/oauth/access_token', attributes, options);
   }
 
   /**
@@ -58,11 +58,11 @@ class Oauth {
    * @param {string} [options.scope] The scope to request during authorization
    * @return {string} The URL to redirect the user to for authorization
    */
-  authorizeUrl(clientId, options = {}) {
-    let siteUrl = this._client.baseUrl().href.replace('api.', '');
+  authorizeUrl (clientId, options = {}) {
+    const siteUrl = this._client.baseUrl().href.replace('api.', '');
     let url = `${siteUrl}oauth/authorize`;
 
-    options = Object.assign(options, {client_id: clientId, response_type: 'code'});
+    options = Object.assign(options, { client_id: clientId, response_type: 'code' });
     url = `${url}?${querystring.stringify(options)}`;
     return url;
   }

--- a/lib/dnsimple/paginate.js
+++ b/lib/dnsimple/paginate.js
@@ -7,7 +7,7 @@
  * list function in its methods).
  */
 class Paginate {
-  constructor(invoker) {
+  constructor (invoker) {
     this._invoker = invoker;
   }
 
@@ -21,10 +21,10 @@ class Paginate {
    * @param {Array} args Array of arguments to pass to the list function.
    * @return {Promise} A Promise that resolves to the full Array of items
    */
-  paginate(listFunction, args) {
+  paginate (listFunction, args) {
     return new Promise((resolve, reject) => {
       this._nextPage(this._invoker, listFunction, args).then((responses) => {
-        let items = [].concat.apply([], responses.map((response) => { return response.data }));
+        const items = [].concat.apply([], responses.map((response) => { return response.data; }));
         resolve(items);
       }, reject);
     });
@@ -37,10 +37,10 @@ class Paginate {
    *
    * @return {Promise}
    */
-  _nextPage(invoker, f, args, page = 1) {
+  _nextPage (invoker, f, args, page = 1) {
     return new Promise((resolve, reject) => {
       // Set the page option to the page argument value
-      Object.assign(args[args.length - 1], {page: page});
+      Object.assign(args[args.length - 1], { page: page });
 
       // Apply the list function on the invoker with the given args
       f.apply(invoker, args).then((response) => {

--- a/lib/dnsimple/registrar.js
+++ b/lib/dnsimple/registrar.js
@@ -6,7 +6,7 @@
  * @see https://developer.dnsimple.com/v2/registrar/
  */
 class Registrar {
-  constructor(client) {
+  constructor (client) {
     this._client = client;
   }
 
@@ -27,7 +27,7 @@ class Registrar {
    * @param {Object} [options]
    * @return {Promise}
    */
-  checkDomain(accountId, domainName, options = {}) {
+  checkDomain (accountId, domainName, options = {}) {
     return this._client.get(this._registrar_path(accountId, domainName, 'check'), options);
   }
 
@@ -48,7 +48,7 @@ class Registrar {
    * @param {Object} [options]
    * @return {Promise}
    */
-  getDomainPremiumPrice(accountId, domainName, options = {}) {
+  getDomainPremiumPrice (accountId, domainName, options = {}) {
     return this._client.get(this._registrar_path(accountId, domainName, 'premium_price'), options);
   }
 
@@ -75,7 +75,7 @@ class Registrar {
    * @param {Object} [options]
    * @return {Promise}
    */
-  registerDomain(accountId, domainName, attributes, options = {}) {
+  registerDomain (accountId, domainName, attributes, options = {}) {
     // Note: registrar_id is required, but no validation occurs here.
     // In the ruby library this is validated.
     return this._client.post(this._registrar_path(accountId, domainName, 'registrations'), attributes, options);
@@ -100,7 +100,7 @@ class Registrar {
    * @param {Object} [options]
    * @return {Promise}
    */
-  renewDomain(accountId, domainName, attributes, options = {}) {
+  renewDomain (accountId, domainName, attributes, options = {}) {
     return this._client.post(this._registrar_path(accountId, domainName, 'renewals'), attributes, options);
   }
 
@@ -123,7 +123,7 @@ class Registrar {
    * @param {Object} [options]
    * @return {Promise}
    */
-  transferDomain(accountId, domainName, attributes, options = {}) {
+  transferDomain (accountId, domainName, attributes, options = {}) {
     // Note: registrar_id is required, but no validation occurs here.
     // In the ruby library this is validated.
     return this._client.post(this._registrar_path(accountId, domainName, 'transfers'), attributes, options);
@@ -146,7 +146,7 @@ class Registrar {
    * @param {Object} [options]
    * @return {Promise}
    */
-  transferDomainOut(accountId, domainName, options = {}) {
+  transferDomainOut (accountId, domainName, options = {}) {
     return this._client.post(this._registrar_path(accountId, domainName, 'authorize_transfer_out'), null, options);
   }
 
@@ -155,7 +155,7 @@ class Registrar {
   /**
    * @deprecated Use `enableDomainAutoRenewal`.
    */
-  enableAutoRenewal(accountId, domainName, options = {}) {
+  enableAutoRenewal (accountId, domainName, options = {}) {
     return this._client.put(this._registrar_path(accountId, domainName, 'auto_renewal'), null, options);
   }
 
@@ -169,14 +169,14 @@ class Registrar {
    * @param {Object} [options]
    * @return {Promise}
    */
-  enableDomainAutoRenewal(accountId, domainName, options = {}) {
+  enableDomainAutoRenewal (accountId, domainName, options = {}) {
     return this._client.put(this._registrar_path(accountId, domainName, 'auto_renewal'), null, options);
   }
 
   /**
    * @deprecated Use `disableDomainAutoRenewal`
    */
-  disableAutoRenewal(accountId, domainName, options = {}) {
+  disableAutoRenewal (accountId, domainName, options = {}) {
     return this._client.delete(this._registrar_path(accountId, domainName, 'auto_renewal'), options);
   }
 
@@ -190,7 +190,7 @@ class Registrar {
    * @param {Object} [options]
    * @return {Promise}
    */
-  disableDomainAutoRenewal(accountId, domainName, options = {}) {
+  disableDomainAutoRenewal (accountId, domainName, options = {}) {
     return this._client.delete(this._registrar_path(accountId, domainName, 'auto_renewal'), options);
   }
 
@@ -206,7 +206,7 @@ class Registrar {
    * @param {Object} [options]
    * @return {Promise}
    */
-  getWhoisPrivacy(accountId, domainName, options = {}) {
+  getWhoisPrivacy (accountId, domainName, options = {}) {
     return this._client.get(this._registrar_path(accountId, domainName, 'whois_privacy'), options);
   }
 
@@ -227,7 +227,7 @@ class Registrar {
    * @param {Object} [options]
    * @return {Promise}
    */
-  enableWhoisPrivacy(accountId, domainName, options = {}) {
+  enableWhoisPrivacy (accountId, domainName, options = {}) {
     return this._client.put(this._registrar_path(accountId, domainName, 'whois_privacy'), null, options);
   }
 
@@ -248,7 +248,7 @@ class Registrar {
    * @param {Object} [options]
    * @return {Promise}
    */
-  disableWhoisPrivacy(accountId, domainName, options = {}) {
+  disableWhoisPrivacy (accountId, domainName, options = {}) {
     return this._client.delete(this._registrar_path(accountId, domainName, 'whois_privacy'), options);
   }
 
@@ -269,7 +269,7 @@ class Registrar {
    * @param {Object} [options]
    * @return {Promise}
    */
-  renewWhoisPrivacy(accountId, domainName, options = {}) {
+  renewWhoisPrivacy (accountId, domainName, options = {}) {
     return this._client.post(this._registrar_path(accountId, domainName, 'whois_privacy/renewals'), null, options);
   }
 
@@ -292,7 +292,7 @@ class Registrar {
    * @param {Object} [options]
    * @return {Promise}
    */
-  getDomainDelegation(accountId, domainName, options = {}) {
+  getDomainDelegation (accountId, domainName, options = {}) {
     return this._client.get(this._registrar_path(accountId, domainName, 'delegation'), options);
   }
 
@@ -315,7 +315,7 @@ class Registrar {
    * @param {Object} [options]
    * @return {Promise}
    */
-  changeDomainDelegation(accountId, domainName, attributes, options = {}) {
+  changeDomainDelegation (accountId, domainName, attributes, options = {}) {
     return this._client.put(this._registrar_path(accountId, domainName, 'delegation'), attributes, options);
   }
 
@@ -338,7 +338,7 @@ class Registrar {
    * @param {Object} [options]
    * @return {Promise}
    */
-  changeDomainDelegationToVanity(accountId, domainName, attributes, options = {}) {
+  changeDomainDelegationToVanity (accountId, domainName, attributes, options = {}) {
     return this._client.put(this._registrar_path(accountId, domainName, 'delegation/vanity'), attributes, options);
   }
 
@@ -359,13 +359,13 @@ class Registrar {
    * @param {Object} [options]
    * @return {Promise}
    */
-  changeDomainDelegationFromVanity(accountId, domainName, options = {}) {
+  changeDomainDelegationFromVanity (accountId, domainName, options = {}) {
     return this._client.delete(this._registrar_path(accountId, domainName, 'delegation/vanity'), options);
   }
 
   // Internal functions
 
-  _registrar_path(accountId, domainName, resource) {
+  _registrar_path (accountId, domainName, resource) {
     return `/${accountId}/registrar/domains/${domainName}/${resource}`;
   }
 }

--- a/lib/dnsimple/registrar.js
+++ b/lib/dnsimple/registrar.js
@@ -28,7 +28,7 @@ class Registrar {
    * @return {Promise}
    */
   checkDomain (accountId, domainName, options = {}) {
-    return this._client.get(this._registrar_path(accountId, domainName, 'check'), options);
+    return this._client.get(this._registrarPath(accountId, domainName, 'check'), options);
   }
 
   /**
@@ -49,7 +49,7 @@ class Registrar {
    * @return {Promise}
    */
   getDomainPremiumPrice (accountId, domainName, options = {}) {
-    return this._client.get(this._registrar_path(accountId, domainName, 'premium_price'), options);
+    return this._client.get(this._registrarPath(accountId, domainName, 'premium_price'), options);
   }
 
   /**
@@ -78,7 +78,7 @@ class Registrar {
   registerDomain (accountId, domainName, attributes, options = {}) {
     // Note: registrar_id is required, but no validation occurs here.
     // In the ruby library this is validated.
-    return this._client.post(this._registrar_path(accountId, domainName, 'registrations'), attributes, options);
+    return this._client.post(this._registrarPath(accountId, domainName, 'registrations'), attributes, options);
   }
 
   /**
@@ -101,7 +101,7 @@ class Registrar {
    * @return {Promise}
    */
   renewDomain (accountId, domainName, attributes, options = {}) {
-    return this._client.post(this._registrar_path(accountId, domainName, 'renewals'), attributes, options);
+    return this._client.post(this._registrarPath(accountId, domainName, 'renewals'), attributes, options);
   }
 
   /**
@@ -126,7 +126,7 @@ class Registrar {
   transferDomain (accountId, domainName, attributes, options = {}) {
     // Note: registrar_id is required, but no validation occurs here.
     // In the ruby library this is validated.
-    return this._client.post(this._registrar_path(accountId, domainName, 'transfers'), attributes, options);
+    return this._client.post(this._registrarPath(accountId, domainName, 'transfers'), attributes, options);
   }
 
   /**
@@ -147,7 +147,7 @@ class Registrar {
    * @return {Promise}
    */
   transferDomainOut (accountId, domainName, options = {}) {
-    return this._client.post(this._registrar_path(accountId, domainName, 'authorize_transfer_out'), null, options);
+    return this._client.post(this._registrarPath(accountId, domainName, 'authorize_transfer_out'), null, options);
   }
 
   // Auto-renewal
@@ -156,7 +156,7 @@ class Registrar {
    * @deprecated Use `enableDomainAutoRenewal`.
    */
   enableAutoRenewal (accountId, domainName, options = {}) {
-    return this._client.put(this._registrar_path(accountId, domainName, 'auto_renewal'), null, options);
+    return this._client.put(this._registrarPath(accountId, domainName, 'auto_renewal'), null, options);
   }
 
   /**
@@ -170,14 +170,14 @@ class Registrar {
    * @return {Promise}
    */
   enableDomainAutoRenewal (accountId, domainName, options = {}) {
-    return this._client.put(this._registrar_path(accountId, domainName, 'auto_renewal'), null, options);
+    return this._client.put(this._registrarPath(accountId, domainName, 'auto_renewal'), null, options);
   }
 
   /**
    * @deprecated Use `disableDomainAutoRenewal`
    */
   disableAutoRenewal (accountId, domainName, options = {}) {
-    return this._client.delete(this._registrar_path(accountId, domainName, 'auto_renewal'), options);
+    return this._client.delete(this._registrarPath(accountId, domainName, 'auto_renewal'), options);
   }
 
   /**
@@ -191,7 +191,7 @@ class Registrar {
    * @return {Promise}
    */
   disableDomainAutoRenewal (accountId, domainName, options = {}) {
-    return this._client.delete(this._registrar_path(accountId, domainName, 'auto_renewal'), options);
+    return this._client.delete(this._registrarPath(accountId, domainName, 'auto_renewal'), options);
   }
 
   // Whois Privacy
@@ -207,7 +207,7 @@ class Registrar {
    * @return {Promise}
    */
   getWhoisPrivacy (accountId, domainName, options = {}) {
-    return this._client.get(this._registrar_path(accountId, domainName, 'whois_privacy'), options);
+    return this._client.get(this._registrarPath(accountId, domainName, 'whois_privacy'), options);
   }
 
   /**
@@ -228,7 +228,7 @@ class Registrar {
    * @return {Promise}
    */
   enableWhoisPrivacy (accountId, domainName, options = {}) {
-    return this._client.put(this._registrar_path(accountId, domainName, 'whois_privacy'), null, options);
+    return this._client.put(this._registrarPath(accountId, domainName, 'whois_privacy'), null, options);
   }
 
   /**
@@ -249,7 +249,7 @@ class Registrar {
    * @return {Promise}
    */
   disableWhoisPrivacy (accountId, domainName, options = {}) {
-    return this._client.delete(this._registrar_path(accountId, domainName, 'whois_privacy'), options);
+    return this._client.delete(this._registrarPath(accountId, domainName, 'whois_privacy'), options);
   }
 
   /**
@@ -270,7 +270,7 @@ class Registrar {
    * @return {Promise}
    */
   renewWhoisPrivacy (accountId, domainName, options = {}) {
-    return this._client.post(this._registrar_path(accountId, domainName, 'whois_privacy/renewals'), null, options);
+    return this._client.post(this._registrarPath(accountId, domainName, 'whois_privacy/renewals'), null, options);
   }
 
   // Domain Delegation
@@ -293,7 +293,7 @@ class Registrar {
    * @return {Promise}
    */
   getDomainDelegation (accountId, domainName, options = {}) {
-    return this._client.get(this._registrar_path(accountId, domainName, 'delegation'), options);
+    return this._client.get(this._registrarPath(accountId, domainName, 'delegation'), options);
   }
 
   /**
@@ -316,7 +316,7 @@ class Registrar {
    * @return {Promise}
    */
   changeDomainDelegation (accountId, domainName, attributes, options = {}) {
-    return this._client.put(this._registrar_path(accountId, domainName, 'delegation'), attributes, options);
+    return this._client.put(this._registrarPath(accountId, domainName, 'delegation'), attributes, options);
   }
 
   /**
@@ -339,7 +339,7 @@ class Registrar {
    * @return {Promise}
    */
   changeDomainDelegationToVanity (accountId, domainName, attributes, options = {}) {
-    return this._client.put(this._registrar_path(accountId, domainName, 'delegation/vanity'), attributes, options);
+    return this._client.put(this._registrarPath(accountId, domainName, 'delegation/vanity'), attributes, options);
   }
 
   /**
@@ -360,12 +360,12 @@ class Registrar {
    * @return {Promise}
    */
   changeDomainDelegationFromVanity (accountId, domainName, options = {}) {
-    return this._client.delete(this._registrar_path(accountId, domainName, 'delegation/vanity'), options);
+    return this._client.delete(this._registrarPath(accountId, domainName, 'delegation/vanity'), options);
   }
 
   // Internal functions
 
-  _registrar_path (accountId, domainName, resource) {
+  _registrarPath (accountId, domainName, resource) {
     return `/${accountId}/registrar/domains/${domainName}/${resource}`;
   }
 }

--- a/lib/dnsimple/services.js
+++ b/lib/dnsimple/services.js
@@ -8,7 +8,7 @@ const Paginate = require('./paginate');
  * @see https://developer.dnsimple.com/v2/services
  */
 class Services {
-  constructor(client) {
+  constructor (client) {
     this._client = client;
   }
 
@@ -44,7 +44,7 @@ class Services {
    * @param {string} [options.sort] The sort definition in the form `key:direction`
    * @return {Promise}
    */
-  listServices(options = {}) {
+  listServices (options = {}) {
     return this._client.get('/services', options);
   }
 
@@ -76,7 +76,7 @@ class Services {
    * @param {string} [options.sort] The sort definition in the form `key:direction`
    * @return {Promise}
    */
-  allServices(options = {}) {
+  allServices (options = {}) {
     return new Paginate(this).paginate(this.listServices, [options]);
   }
 
@@ -89,7 +89,7 @@ class Services {
    * @param {Object} [options]
    * @return {Promise}
    */
-  getService(serviceId, options = {}) {
+  getService (serviceId, options = {}) {
     return this._client.get(`/services/${serviceId}`, options);
   }
 
@@ -127,7 +127,7 @@ class Services {
    * @param {string} [options.sort] The sort definition in the form `key:direction`
    * @return {Promise}
    */
-  appliedServices(accountId, domainId, options = {}) {
+  appliedServices (accountId, domainId, options = {}) {
     return this._client.get(`/${accountId}/domains/${domainId}/services`, options);
   }
 
@@ -161,7 +161,7 @@ class Services {
    * @param {string} [options.sort] The sort definition in the form `key:direction`
    * @return {Promise}
    */
-  allAppliedServices(accountId, domainId, options = {}) {
+  allAppliedServices (accountId, domainId, options = {}) {
     return new Paginate(this).paginate(this.appliedServices, [accountId, domainId, options]);
   }
 
@@ -176,7 +176,7 @@ class Services {
    * @param {Object} [options]
    * @return {Promise}
    */
-  applyService(accountId, domainId, serviceId, options = {}) {
+  applyService (accountId, domainId, serviceId, options = {}) {
     return this._client.post(`/${accountId}/domains/${domainId}/services/${serviceId}`, null, options);
   }
 
@@ -191,7 +191,7 @@ class Services {
    * @param {Object} [options]
    * @return {Promise}
    */
-  unapplyService(accountId, domainId, serviceId, options = {}) {
+  unapplyService (accountId, domainId, serviceId, options = {}) {
     return this._client.delete(`/${accountId}/domains/${domainId}/services/${serviceId}`, options);
   }
 }

--- a/lib/dnsimple/templates.js
+++ b/lib/dnsimple/templates.js
@@ -8,7 +8,7 @@ const Paginate = require('./paginate');
  * @see https://developer.dnsimple.com/v2/templates
  */
 class Templates {
-  constructor(client) {
+  constructor (client) {
     this._client = client;
   }
 
@@ -45,7 +45,7 @@ class Templates {
    * @param {string} [options.sort] The sort definition in the form `key:direction`
    * @return {Promise}
    */
-  listTemplates(accountId, options = {}) {
+  listTemplates (accountId, options = {}) {
     return this._client.get(`/${accountId}/templates`, options);
   }
 
@@ -78,7 +78,7 @@ class Templates {
    * @param {string} [options.sort] The sort definition in the form `key:direction`
    * @return {Promise}
    */
-  allTemplates(accountId, options = {}) {
+  allTemplates (accountId, options = {}) {
     return new Paginate(this).paginate(this.listTemplates, [accountId, options]);
   }
 
@@ -92,7 +92,7 @@ class Templates {
    * @param {Object} [options]
    * @return {Promise}
    */
-  getTemplate(accountId, templateId, options = {}) {
+  getTemplate (accountId, templateId, options = {}) {
     return this._client.get(`/${accountId}/templates/${templateId}`, options);
   }
 
@@ -106,7 +106,7 @@ class Templates {
    * @param {Object} [options]
    * @return {Promise}
    */
-  createTemplate(accountId, attributes, options = {}) {
+  createTemplate (accountId, attributes, options = {}) {
     return this._client.post(`/${accountId}/templates`, attributes, options);
   }
 
@@ -121,7 +121,7 @@ class Templates {
    * @param {Object} [options]
    * @return {Promise}
    */
-  updateTemplate(accountId, templateId, attributes, options = {}) {
+  updateTemplate (accountId, templateId, attributes, options = {}) {
     return this._client.patch(`/${accountId}/templates/${templateId}`, attributes, options);
   }
 
@@ -135,7 +135,7 @@ class Templates {
    * @param {Object} [options]
    * @return {Promise}
    */
-  deleteTemplate(accountId, templateId, options = {}) {
+  deleteTemplate (accountId, templateId, options = {}) {
     return this._client.delete(`/${accountId}/templates/${templateId}`, options);
   }
 
@@ -150,7 +150,7 @@ class Templates {
    * @param {Object} [options]
    * @return {Promise}
    */
-  applyTemplate(accountId, templateId, domainId, options = {}) {
+  applyTemplate (accountId, templateId, domainId, options = {}) {
     return this._client.post(`/${accountId}/domains/${domainId}/templates/${templateId}`, null, options);
   }
 
@@ -188,7 +188,7 @@ class Templates {
    * @param {string} [options.sort] The sort definition in the form `key:direction`
    * @return {Promise}
    */
-  listTemplateRecords(accountId, templateId, options = {}) {
+  listTemplateRecords (accountId, templateId, options = {}) {
     return this._client.get(`/${accountId}/templates/${templateId}/records`, options);
   }
 
@@ -222,7 +222,7 @@ class Templates {
    * @param {string} [options.sort] The sort definition in the form `key:direction`
    * @return {Promise}
    */
-  allTemplateRecords(accountId, domainId, options = {}) {
+  allTemplateRecords (accountId, domainId, options = {}) {
     return new Paginate(this).paginate(this.listTemplateRecords, [accountId, domainId, options]);
   }
 
@@ -237,7 +237,7 @@ class Templates {
    * @param {Object} [options]
    * @return {Promise}
    */
-  getTemplateRecord(accountId, templateId, recordId, options = {}) {
+  getTemplateRecord (accountId, templateId, recordId, options = {}) {
     return this._client.get(`/${accountId}/templates/${templateId}/records/${recordId}`, options);
   }
 
@@ -252,7 +252,7 @@ class Templates {
    * @param {Object} [options]
    * @return {Promise}
    */
-  createTemplateRecord(accountId, templateId, attributes, options = {}) {
+  createTemplateRecord (accountId, templateId, attributes, options = {}) {
     return this._client.post(`/${accountId}/templates/${templateId}/records`, attributes, options);
   }
 
@@ -267,7 +267,7 @@ class Templates {
    * @param {Object} [options]
    * @return {Promise}
    */
-  deleteTemplateRecord(accountId, templateId, recordId, options = {}) {
+  deleteTemplateRecord (accountId, templateId, recordId, options = {}) {
     return this._client.delete(`/${accountId}/templates/${templateId}/records/${recordId}`, options);
   }
 }

--- a/lib/dnsimple/tlds.js
+++ b/lib/dnsimple/tlds.js
@@ -8,7 +8,7 @@ const Paginate = require('./paginate');
  * @see https://developer.dnsimple.com/v2/tlds
  */
 class Tlds {
-  constructor(client) {
+  constructor (client) {
     this._client = client;
   }
 
@@ -44,7 +44,7 @@ class Tlds {
    * @param {string} [options.sort] The sort definition in the form `key:direction`
    * @return {Promise}
    */
-  listTlds(options = {}) {
+  listTlds (options = {}) {
     return this._client.get('/tlds', options);
   }
 
@@ -76,10 +76,9 @@ class Tlds {
    * @param {string} [options.sort] The sort definition in the form `key:direction`
    * @return {Promise}
    */
-  allTlds(options = {}) {
+  allTlds (options = {}) {
     return new Paginate(this).paginate(this.listTlds, [options]);
   }
-
 
   /**
    * Get details for a TLD.
@@ -97,7 +96,7 @@ class Tlds {
    * @param {Object} [options]
    * @return {Promise}
    */
-  getTld(tld, options = {}) {
+  getTld (tld, options = {}) {
     return this._client.get(`/tlds/${tld}`, options);
   }
 
@@ -117,10 +116,9 @@ class Tlds {
    * @param {Object} [options]
    * @return {Promise}
    */
-  getTldExtendedAttributes(tld, options = {}) {
+  getTldExtendedAttributes (tld, options = {}) {
     return this._client.get(`/tlds/${tld}/extended_attributes`, options);
   }
-
 }
 
 module.exports = Tlds;

--- a/lib/dnsimple/vanity_name_servers.js
+++ b/lib/dnsimple/vanity_name_servers.js
@@ -6,7 +6,7 @@
  * @see https://developer.dnsimple.com/v2/domains/vanity
  */
 class VanityNameServers {
-  constructor(client) {
+  constructor (client) {
     this._client = client;
   }
 
@@ -20,7 +20,7 @@ class VanityNameServers {
    * @param {Object} [options]
    * @return {Promise}
    */
-  enableVanityNameServers(accountId, domainId, options = {}) {
+  enableVanityNameServers (accountId, domainId, options = {}) {
     return this._client.put(`/${accountId}/vanity/${domainId}`, null, options);
   }
 
@@ -34,7 +34,7 @@ class VanityNameServers {
    * @param {Object} [options]
    * @return {Promise}
    */
-  disableVanityNameServers(accountId, domainId, options = {}) {
+  disableVanityNameServers (accountId, domainId, options = {}) {
     return this._client.delete(`/${accountId}/vanity/${domainId}`, options);
   }
 }

--- a/lib/dnsimple/webhooks.js
+++ b/lib/dnsimple/webhooks.js
@@ -6,7 +6,7 @@
  * @see https://developer.dnsimple.com/v2/webhooks
  */
 class Webhooks {
-  constructor(client) {
+  constructor (client) {
     this._client = client;
   }
 
@@ -26,7 +26,7 @@ class Webhooks {
    * @param {Object} [options]
    * @return {Promise}
    */
-  listWebhooks(accountId, options = {}) {
+  listWebhooks (accountId, options = {}) {
     return this._client.get(`/${accountId}/webhooks`, options);
   }
 
@@ -40,12 +40,12 @@ class Webhooks {
    * @param {Object} [options]
    * @return {Promise}
    */
-  allWebhooks(accountId, options = {}) {
+  allWebhooks (accountId, options = {}) {
     var self = this;
-    return new Promise(function(resolve, reject) {
-      self.listWebhooks(accountId, options).then(function(response) {
+    return new Promise(function (resolve, reject) {
+      self.listWebhooks(accountId, options).then(function (response) {
         resolve(response.data);
-      }, function(error) {
+      }, function (error) {
         reject(error);
       });
     });
@@ -61,7 +61,7 @@ class Webhooks {
    * @param {Object} [options]
    * @return {Promise}
    */
-  getWebhook(accountId, webhookId, options = {}) {
+  getWebhook (accountId, webhookId, options = {}) {
     return this._client.get(`/${accountId}/webhooks/${webhookId}`, options);
   }
 
@@ -75,7 +75,7 @@ class Webhooks {
    * @param {Object} [options]
    * @return {Promise}
    */
-  createWebhook(accountId, attributes, options = {}) {
+  createWebhook (accountId, attributes, options = {}) {
     return this._client.post(`/${accountId}/webhooks`, attributes, options);
   }
 
@@ -90,7 +90,7 @@ class Webhooks {
    * @return {Promise}
    */
 
-  deleteWebhook(accountId, webhookId, options = {}) {
+  deleteWebhook (accountId, webhookId, options = {}) {
     return this._client.delete(`/${accountId}/webhooks/${webhookId}`, options);
   }
 }

--- a/lib/dnsimple/zones.js
+++ b/lib/dnsimple/zones.js
@@ -8,7 +8,7 @@ const Paginate = require('./paginate');
  * @see https://developer.dnsimple.com/v2/zones/
  */
 class Zones {
-  constructor(client) {
+  constructor (client) {
     this._client = client;
   }
 
@@ -53,7 +53,7 @@ class Zones {
    * @param {string} [options.name_like] Filter zones where the name is like the given string
    * @return {Promise}
    */
-  listZones(accountId, options = {}) {
+  listZones (accountId, options = {}) {
     return this._client.get(`/${accountId}/zones`, options);
   }
 
@@ -94,7 +94,7 @@ class Zones {
    * @param {string} [options.name_like] Filter zones where the name is like the given string
    * @return {Promise}
    */
-  allZones(accountId, options = {}) {
+  allZones (accountId, options = {}) {
     return new Paginate(this).paginate(this.listZones, [accountId, options]);
   }
 
@@ -108,7 +108,7 @@ class Zones {
    * @param {Object} [options]
    * @return {Promise}
    */
-  getZone(accountId, zoneId, options = {}) {
+  getZone (accountId, zoneId, options = {}) {
     return this._client.get(`/${accountId}/zones/${zoneId}`, options);
   }
 
@@ -122,7 +122,7 @@ class Zones {
    * @param {Object} [options]
    * @return {Promise}
    */
-  getZoneFile(accountId, zoneId, options = {}) {
+  getZoneFile (accountId, zoneId, options = {}) {
     return this._client.get(`/${accountId}/zones/${zoneId}/file`, options);
   }
 
@@ -136,7 +136,7 @@ class Zones {
    * @param {Object} [options]
    * @return {Promise}
    */
-  checkZoneDistribution(accountId, zoneId, options = {}) {
+  checkZoneDistribution (accountId, zoneId, options = {}) {
     return this._client.get(`/${accountId}/zones/${zoneId}/distribution`, options);
   }
 
@@ -151,7 +151,7 @@ class Zones {
    * @param {Object} [options]
    * @return {Promise}
    */
-  checkZoneRecordDistribution(accountId, zoneId, recordId, options = {}) {
+  checkZoneRecordDistribution (accountId, zoneId, recordId, options = {}) {
     return this._client.get(`/${accountId}/zones/${zoneId}/records/${recordId}/distribution`, options);
   }
 
@@ -189,7 +189,7 @@ class Zones {
    * @param {string} [options.sort] The sort definition in the form `key:direction`
    * @return {Promise}
    */
-  listZoneRecords(accountId, zoneId, options = {}) {
+  listZoneRecords (accountId, zoneId, options = {}) {
     return this._client.get(`/${accountId}/zones/${zoneId}/records`, options);
   }
 
@@ -223,7 +223,7 @@ class Zones {
    * @param {string} [options.sort] The sort definition in the form `key:direction`
    * @return {Promise}
    */
-  allZoneRecords(accountId, zoneId, options = {}) {
+  allZoneRecords (accountId, zoneId, options = {}) {
     return new Paginate(this).paginate(this.listZoneRecords, [accountId, zoneId, options]);
   }
 
@@ -238,7 +238,7 @@ class Zones {
    * @param {Object} [options]
    * @return {Promise}
    */
-  getZoneRecord(accountId, zoneId, recordId, options = {}) {
+  getZoneRecord (accountId, zoneId, recordId, options = {}) {
     return this._client.get(`/${accountId}/zones/${zoneId}/records/${recordId}`, options);
   }
 
@@ -253,7 +253,7 @@ class Zones {
    * @param {Object} [options]
    * @return {Promise}
    */
-  createZoneRecord(accountId, zoneId, attributes, options = {}) {
+  createZoneRecord (accountId, zoneId, attributes, options = {}) {
     return this._client.post(`/${accountId}/zones/${zoneId}/records`, attributes, options);
   }
 
@@ -269,7 +269,7 @@ class Zones {
    * @param {Object} [options]
    * @return {Promise}
    */
-  updateZoneRecord(accountId, zoneId, recordId, attributes, options = {}) {
+  updateZoneRecord (accountId, zoneId, recordId, attributes, options = {}) {
     return this._client.patch(`/${accountId}/zones/${zoneId}/records/${recordId}`, attributes, options);
   }
 
@@ -284,7 +284,7 @@ class Zones {
    * @param {Object} [options]
    * @return {Promise}
    */
-  deleteZoneRecord(accountId, zoneId, recordId, options = {}) {
+  deleteZoneRecord (accountId, zoneId, recordId, options = {}) {
     return this._client.delete(`/${accountId}/zones/${zoneId}/records/${recordId}`, options);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,76 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.8.3"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+      "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "acorn": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+      "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
     "ansi-colors": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
       "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
       "dev": true
+    },
+    "ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
     },
     "anymatch": {
       "version": "3.1.1",
@@ -29,10 +94,27 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "array-includes": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.1.tgz",
+      "integrity": "sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0",
+        "is-string": "^1.0.5"
+      }
+    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
     "balanced-match": {
@@ -72,6 +154,18 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -109,6 +203,23 @@
         "check-error": "^1.0.2"
       }
     },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -130,6 +241,21 @@
         "normalize-path": "~3.0.0",
         "readdirp": "~3.2.0"
       }
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
     },
     "cliui": {
       "version": "5.0.0",
@@ -191,6 +317,45 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "contains-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
     "debug": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -208,6 +373,12 @@
         }
       }
     },
+    "debug-log": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+      "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
+      "dev": true
+    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -223,6 +394,12 @@
         "type-detect": "^4.0.0"
       }
     },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -232,17 +409,57 @@
         "object-keys": "^1.0.12"
       }
     },
+    "deglob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/deglob/-/deglob-4.0.1.tgz",
+      "integrity": "sha512-/g+RDZ7yf2HvoW+E5Cy+K94YhgcFgr6C8LuHZD1O5HoNPkf3KY6RfXJ0DBGlB/NkLi5gml+G9zqRzk9S0mHZCg==",
+      "dev": true,
+      "requires": {
+        "find-root": "^1.0.0",
+        "glob": "^7.0.5",
+        "ignore": "^5.0.0",
+        "pkg-config": "^1.1.0",
+        "run-parallel": "^1.1.2",
+        "uniq": "^1.0.1"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+          "dev": true
+        }
+      }
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
     },
     "es-abstract": {
       "version": "1.17.4",
@@ -280,11 +497,378 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "eslint": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.4.0.tgz",
+      "integrity": "sha512-WTVEzK3lSFoXUovDHEbkJqCVPEPwbhCq4trDktNI6ygs7aO41d4cDT0JFAT5MivzZeVLWlg7vHL+bgrQv/t3vA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.10.0",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^1.4.2",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.1.1",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^6.4.1",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.14",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^6.1.2",
+        "strip-ansi": "^5.2.0",
+        "strip-json-comments": "^3.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "eslint-config-semistandard": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-semistandard/-/eslint-config-semistandard-15.0.0.tgz",
+      "integrity": "sha512-volIMnosUvzyxGkYUA5QvwkahZZLeUx7wcS0+7QumPn+MMEBbV6P7BY1yukamMst0w3Et3QZlCjQEwQ8tQ6nug==",
+      "dev": true
+    },
+    "eslint-config-standard": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.0.tgz",
+      "integrity": "sha512-EF6XkrrGVbvv8hL/kYa/m6vnvmUT+K82pJJc4JJVMM6+Qgqh0pnwprSxdduDLB9p/7bIxD+YV5O0wfb8lmcPbA==",
+      "dev": true
+    },
+    "eslint-config-standard-jsx": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-8.1.0.tgz",
+      "integrity": "sha512-ULVC8qH8qCqbU792ZOO6DaiaZyHNS/5CZt3hKqHkEhVlhPEPN3nfBqqxJCyp59XrjIBZPu1chMYe9T2DXZ7TMw==",
+      "dev": true
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz",
+      "integrity": "sha512-b8crLDo0M5RSe5YG8Pu2DYBj71tSB6OvXkfzwbJU2w7y8P4/yo0MyF8jU26IEuEuHF2K5/gcAJE3LhQGqBBbVg==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.9",
+        "resolve": "^1.13.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.5.2.tgz",
+      "integrity": "sha512-LGScZ/JSlqGKiT8OC+cYRxseMjyqt6QO54nl281CK93unD89ijSeRV6An8Ci/2nvWVKe8K/Tqdm75RQoIOCr+Q==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.9",
+        "pkg-dir": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-es": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-2.0.0.tgz",
+      "integrity": "sha512-f6fceVtg27BR02EYnBhgWLFQfK6bN4Ll0nQFrBHOlCsAyxeZkn0NHns5O0YZOPrV1B3ramd6cgFwaoFLcSkwEQ==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^1.4.2",
+        "regexpp": "^3.0.0"
+      },
+      "dependencies": {
+        "regexpp": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
+          "integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.18.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
+      "integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3",
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.9",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "^0.3.2",
+        "eslint-module-utils": "^2.4.0",
+        "has": "^1.0.3",
+        "minimatch": "^3.0.4",
+        "object.values": "^1.1.0",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.11.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "doctrine": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-node": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-10.0.0.tgz",
+      "integrity": "sha512-1CSyM/QCjs6PXaT18+zuAXsjXGIGo5Rw630rSKwokSs2jrYURQc4R5JZpoanNCqwNmepg+0eZ9L7YiRUJb8jiQ==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-es": "^2.0.0",
+        "eslint-utils": "^1.4.2",
+        "ignore": "^5.1.1",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.10.1",
+        "semver": "^6.1.0"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-promise": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
+      "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
+      "dev": true
+    },
+    "eslint-plugin-react": {
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz",
+      "integrity": "sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3",
+        "doctrine": "^2.1.0",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.1.0",
+        "object.entries": "^1.1.0",
+        "object.fromentries": "^2.0.0",
+        "object.values": "^1.1.0",
+        "prop-types": "^15.7.2",
+        "resolve": "^1.10.1"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        }
+      }
+    },
+    "eslint-plugin-standard": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.1.tgz",
+      "integrity": "sha512-v/KBnfyaOMPmZc/dmc6ozOdWqekGp7bBGq4jLAecEfPGmfKiWS4sA8sC0LqiV9w5qmXAtXVn4M3p1jSyhY85SQ==",
+      "dev": true
+    },
+    "eslint-scope": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+      "dev": true
+    },
+    "espree": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.0.tgz",
+      "integrity": "sha512-Xs8airJ7RQolnDIbLtRutmfvSsAe0xqMMAantCN/GMoqf81TFbeI1T7Jpd56qYu1uuh32dOG5W/X9uO+ghPXzA==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.1.0",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
+    },
+    "esquery": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz",
+      "integrity": "sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^2.0.1"
+      }
     },
     "fill-range": {
       "version": "7.0.1",
@@ -294,6 +878,12 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
+    },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "dev": true
     },
     "find-up": {
       "version": "3.0.0",
@@ -312,6 +902,23 @@
       "requires": {
         "is-buffer": "~2.0.3"
       }
+    },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      }
+    },
+    "flatted": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -332,6 +939,12 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -344,6 +957,26 @@
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
+    "get-stdin": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+      "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
     "glob-parent": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
@@ -352,6 +985,18 @@
       "requires": {
         "is-glob": "^4.0.1"
       }
+    },
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
+    },
+    "graceful-fs": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+      "dev": true
     },
     "growl": {
       "version": "1.10.5",
@@ -386,6 +1031,43 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "hosted-git-info": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -400,6 +1082,33 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+      "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.12",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.1.0",
+        "through": "^2.3.6"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-binary-path": {
@@ -456,6 +1165,12 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
     "is-regex": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
@@ -464,6 +1179,12 @@
       "requires": {
         "has": "^1.0.3"
       }
+    },
+    "is-string": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+      "dev": true
     },
     "is-symbol": {
       "version": "1.0.3",
@@ -474,10 +1195,22 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
     "js-yaml": {
@@ -490,11 +1223,61 @@
         "esprima": "^4.0.0"
       }
     },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
+    },
+    "jsx-ast-utils": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.3.tgz",
+      "integrity": "sha512-EdIHFMm+1BPynpKOpdPqiOsvnIrInRGJD7bzPZdPkjitQEqpdpUuFpq4T0npZFKTiB3RhWFdGN+oqOJIdhDhQA==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3",
+        "object.assign": "^4.1.0"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "load-json-file": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "strip-bom": "^3.0.0"
+      }
     },
     "locate-path": {
       "version": "3.0.0",
@@ -552,6 +1335,21 @@
         }
       }
     },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -560,6 +1358,12 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -653,6 +1457,24 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
     "nock": {
       "version": "12.0.2",
       "resolved": "https://registry.npmjs.org/nock/-/nock-12.0.2.tgz",
@@ -694,10 +1516,36 @@
         }
       }
     },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
     "object-inspect": {
@@ -724,6 +1572,30 @@
         "object-keys": "^1.0.11"
       }
     },
+    "object.entries": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.1.tgz",
+      "integrity": "sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
+    "object.fromentries": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.2.tgz",
+      "integrity": "sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
     "object.getownpropertydescriptors": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
@@ -734,6 +1606,18 @@
         "es-abstract": "^1.17.0-next.1"
       }
     },
+    "object.values": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
+      "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -742,6 +1626,35 @@
       "requires": {
         "wrappy": "1"
       }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
+    },
+    "optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
     },
     "p-limit": {
       "version": "2.2.2",
@@ -767,6 +1680,24 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.2.0"
+      }
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -779,17 +1710,262 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "path-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+      "dev": true,
+      "requires": {
+        "pify": "^2.0.0"
+      }
+    },
     "picomatch": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
       "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
       "dev": true
     },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pkg-conf": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
+      "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0",
+        "load-json-file": "^5.2.0"
+      },
+      "dependencies": {
+        "load-json-file": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+          "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.15",
+            "parse-json": "^4.0.0",
+            "pify": "^4.0.1",
+            "strip-bom": "^3.0.0",
+            "type-fest": "^0.3.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        }
+      }
+    },
+    "pkg-config": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
+      "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
+      "dev": true,
+      "requires": {
+        "debug-log": "^1.0.0",
+        "find-root": "^1.0.0",
+        "xtend": "^4.0.1"
+      }
+    },
+    "pkg-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        }
+      }
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
+    },
     "propagate": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
       "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
       "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "react-is": {
+      "version": "16.13.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",
+      "integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==",
+      "dev": true
+    },
+    "read-pkg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^2.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^2.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
     },
     "readdirp": {
       "version": "3.2.0",
@@ -799,6 +1975,12 @@
       "requires": {
         "picomatch": "^2.0.4"
       }
+    },
+    "regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
     },
     "require-directory": {
       "version": "2.1.1",
@@ -812,10 +1994,200 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
+    "resolve": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+      "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "run-async": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
+      "integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "dev": true
+    },
+    "rxjs": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
+      "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "semistandard": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/semistandard/-/semistandard-14.2.0.tgz",
+      "integrity": "sha512-mQ0heTpbW7WWBXKOIqitlfEcAZhgGTwaHr1zzv70PnZZc53J+4u31+vLUEsh2oKVWfVgcjrykT2hz02B1Cfaaw==",
+      "dev": true,
+      "requires": {
+        "eslint": "~6.4.0",
+        "eslint-config-semistandard": "15.0.0",
+        "eslint-config-standard": "14.1.0",
+        "eslint-config-standard-jsx": "8.1.0",
+        "eslint-plugin-import": "~2.18.0",
+        "eslint-plugin-node": "~10.0.0",
+        "eslint-plugin-promise": "~4.2.1",
+        "eslint-plugin-react": "~7.14.2",
+        "eslint-plugin-standard": "~4.0.0",
+        "standard-engine": "^12.0.0"
+      }
+    },
+    "semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true
+    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "snazzy": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/snazzy/-/snazzy-8.0.0.tgz",
+      "integrity": "sha512-59GS69hQD8FvJoNGeDz8aZtbYhkCFxCPQB1BFzAWiVVwPmS/J6Vjaku0k6tGNsdSxQ0kAlButdkn8bPR2hLcBw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.0",
+        "inherits": "^2.0.1",
+        "minimist": "^1.1.1",
+        "readable-stream": "^3.0.2",
+        "standard-json": "^1.0.0",
+        "strip-ansi": "^4.0.0",
+        "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
+    "spdx-correct": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
     "sprintf-js": {
@@ -823,6 +2195,27 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "standard-engine": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-12.0.0.tgz",
+      "integrity": "sha512-gJIIRb0LpL7AHyGbN9+hJ4UJns37lxmNTnMGRLC8CFrzQ+oB/K60IQjKNgPBCB2VP60Ypm6f8DFXvhVWdBOO+g==",
+      "dev": true,
+      "requires": {
+        "deglob": "^4.0.0",
+        "get-stdin": "^7.0.0",
+        "minimist": "^1.1.0",
+        "pkg-conf": "^3.1.0"
+      }
+    },
+    "standard-json": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/standard-json/-/standard-json-1.1.0.tgz",
+      "integrity": "sha512-nkonX+n5g3pyVBvJZmvRlFtT/7JyLbNh4CtrYC3Qfxihgs8PKX52f6ONKQXORStuBWJ5PI83EUrNXme7LKfiTQ==",
+      "dev": true,
+      "requires": {
+        "concat-stream": "^2.0.0"
+      }
     },
     "string-width": {
       "version": "2.1.1",
@@ -871,6 +2264,91 @@
         "function-bind": "^1.1.1"
       }
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^4.1.0"
+      }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+      "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "table": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        }
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -880,11 +2358,75 @@
         "is-number": "^7.0.0"
       }
     },
+    "tslib": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
+    },
+    "type-fest": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+      "dev": true
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "v8-compile-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+      "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
     },
     "which": {
       "version": "1.3.1",
@@ -909,6 +2451,12 @@
       "requires": {
         "string-width": "^1.0.2 || 2"
       }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "5.1.0",
@@ -962,6 +2510,21 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true
     },
     "y18n": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -560,9 +560,9 @@
       "dev": true
     },
     "eslint-config-standard": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.0.tgz",
-      "integrity": "sha512-EF6XkrrGVbvv8hL/kYa/m6vnvmUT+K82pJJc4JJVMM6+Qgqh0pnwprSxdduDLB9p/7bIxD+YV5O0wfb8lmcPbA==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-13.0.1.tgz",
+      "integrity": "sha512-zLKp4QOgq6JFgRm1dDCVv1Iu0P5uZ4v5Wa4DTOkg2RFMxdCX/9Qf7lz9ezRj2dBRa955cWQF/O/LWEiYWAHbTw==",
       "dev": true
     },
     "eslint-config-standard-jsx": {
@@ -2080,6 +2080,14 @@
         "eslint-plugin-react": "~7.14.2",
         "eslint-plugin-standard": "~4.0.0",
         "standard-engine": "^12.0.0"
+      },
+      "dependencies": {
+        "eslint-config-standard": {
+          "version": "14.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.0.tgz",
+          "integrity": "sha512-EF6XkrrGVbvv8hL/kYa/m6vnvmUT+K82pJJc4JJVMM6+Qgqh0pnwprSxdduDLB9p/7bIxD+YV5O0wfb8lmcPbA==",
+          "dev": true
+        }
       }
     },
     "semver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,28 +4,10 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "JSV": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
-      "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c=",
-      "dev": true
-    },
     "ansi-colors": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
       "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
-      "dev": true
-    },
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
-    },
-    "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
     "anymatch": {
@@ -51,28 +33,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true
-    },
-    "async": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-      "dev": true
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
-    "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
     },
     "balanced-match": {
@@ -149,19 +109,6 @@
         "check-error": "^1.0.2"
       }
     },
-    "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
-      }
-    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -182,15 +129,6 @@
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
         "readdirp": "~3.2.0"
-      }
-    },
-    "cli-table": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
-      "dev": true,
-      "requires": {
-        "colors": "1.0.3"
       }
     },
     "cliui": {
@@ -247,95 +185,10 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
-    "colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-      "dev": true
-    },
-    "commander": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true,
-      "requires": {
-        "graceful-readlink": ">= 1.0.0"
-      }
-    },
-    "comment-parser": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.3.2.tgz",
-      "integrity": "sha1-PAPwd2uGo239mgosl8YwfzMggv4=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "^2.0.4"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
-    },
-    "core-js": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
-      "dev": true
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
-    },
-    "cst": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/cst/-/cst-0.4.10.tgz",
-      "integrity": "sha512-U5ETe1IOjq2h56ZcBE3oe9rT7XryCH6IKgPMv0L7sSk6w29yR3p5egCK0T3BDNHHV95OoUBgXsqiVG+3a900Ag==",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.9.2",
-        "babylon": "^6.8.1",
-        "source-map-support": "^0.4.0"
-      }
-    },
-    "cycle": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
       "dev": true
     },
     "debug": {
@@ -370,12 +223,6 @@
         "type-detect": "^4.0.0"
       }
     },
-    "deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-      "dev": true
-    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -391,65 +238,10 @@
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
-    "dom-serializer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
-      "dev": true,
-      "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
-      },
-      "dependencies": {
-        "domelementtype": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
-          "dev": true
-        },
-        "entities": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-          "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
-          "dev": true
-        }
-      }
-    },
-    "domelementtype": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
-      "dev": true
-    },
-    "domhandler": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
-      "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
-      "dev": true,
-      "requires": {
-        "domelementtype": "1"
-      }
-    },
-    "domutils": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-      "dev": true,
-      "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
-      }
-    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "dev": true
-    },
-    "entities": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
-      "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
       "dev": true
     },
     "es-abstract": {
@@ -492,24 +284,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
-    },
-    "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-      "dev": true
-    },
-    "exit": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-      "dev": true
-    },
-    "eyes": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
       "dev": true
     },
     "fill-range": {
@@ -570,19 +344,6 @@
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
-    "glob": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-      "dev": true,
-      "requires": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
     "glob-parent": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
@@ -591,12 +352,6 @@
       "requires": {
         "is-glob": "^4.0.1"
       }
-    },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-      "dev": true
     },
     "growl": {
       "version": "1.10.5",
@@ -612,21 +367,6 @@
       "requires": {
         "function-bind": "^1.1.1"
       }
-    },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
-    },
-    "has-color": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
-      "dev": true
     },
     "has-flag": {
       "version": "3.0.0",
@@ -646,25 +386,6 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
-    "htmlparser2": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
-      "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
-      "dev": true,
-      "requires": {
-        "domelementtype": "1",
-        "domhandler": "2.3",
-        "domutils": "1.5",
-        "entities": "1.0",
-        "readable-stream": "1.1"
-      }
-    },
-    "i": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
-      "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0=",
-      "dev": true
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -674,12 +395,6 @@
         "once": "^1.3.0",
         "wrappy": "1"
       }
-    },
-    "inherit": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/inherit/-/inherit-2.2.7.tgz",
-      "integrity": "sha512-dxJmC1j0Q32NFAjvbd6g3lXYLZ49HgzotgbSMwMkoiTXGhC9412Oc24g7A7M9cPPkw/vDsF2cSII+2zJwocUtQ==",
-      "dev": true
     },
     "inherits": {
       "version": "2.0.3",
@@ -759,28 +474,10 @@
         "has-symbols": "^1.0.1"
       }
     },
-    "is-utf8": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true
-    },
-    "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-      "dev": true
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
     "js-yaml": {
@@ -793,113 +490,11 @@
         "esprima": "^4.0.0"
       }
     },
-    "jscs": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/jscs/-/jscs-3.0.7.tgz",
-      "integrity": "sha1-cUG03/W4bjLQ6Z12S4NnZ8MNIBo=",
-      "dev": true,
-      "requires": {
-        "chalk": "~1.1.0",
-        "cli-table": "~0.3.1",
-        "commander": "~2.9.0",
-        "cst": "^0.4.3",
-        "estraverse": "^4.1.0",
-        "exit": "~0.1.2",
-        "glob": "^5.0.1",
-        "htmlparser2": "3.8.3",
-        "js-yaml": "~3.4.0",
-        "jscs-jsdoc": "^2.0.0",
-        "jscs-preset-wikimedia": "~1.0.0",
-        "jsonlint": "~1.6.2",
-        "lodash": "~3.10.0",
-        "minimatch": "~3.0.0",
-        "natural-compare": "~1.2.2",
-        "pathval": "~0.1.1",
-        "prompt": "~0.2.14",
-        "reserved-words": "^0.1.1",
-        "resolve": "^1.1.6",
-        "strip-bom": "^2.0.0",
-        "strip-json-comments": "~1.0.2",
-        "to-double-quotes": "^2.0.0",
-        "to-single-quotes": "^2.0.0",
-        "vow": "~0.4.8",
-        "vow-fs": "~0.3.4",
-        "xmlbuilder": "^3.1.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "3.4.6",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
-          "integrity": "sha1-a+GyP2JJ9T0pM3D9TRqqY84bTrA=",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.2",
-            "esprima": "^2.6.0",
-            "inherit": "^2.2.2"
-          }
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        }
-      }
-    },
-    "jscs-jsdoc": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/jscs-jsdoc/-/jscs-jsdoc-2.0.0.tgz",
-      "integrity": "sha1-9T684CmqMSW9iCkLpQ1k1FEKSHE=",
-      "dev": true,
-      "requires": {
-        "comment-parser": "^0.3.1",
-        "jsdoctypeparser": "~1.2.0"
-      }
-    },
-    "jscs-preset-wikimedia": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/jscs-preset-wikimedia/-/jscs-preset-wikimedia-1.0.1.tgz",
-      "integrity": "sha512-RWqu6IYSUlnYuCRCF0obCOHjJV0vhpLcvKbauwxmLQoZ0PiXDTWBYlfpsEfdhg7pmREAEwrARfDRz5qWD6qknA==",
-      "dev": true
-    },
-    "jsdoctypeparser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-1.2.0.tgz",
-      "integrity": "sha1-597cFToRhJ/8UUEUSuhqfvDCU5I=",
-      "dev": true,
-      "requires": {
-        "lodash": "^3.7.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        }
-      }
-    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
-    },
-    "jsonlint": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.3.tgz",
-      "integrity": "sha512-jMVTMzP+7gU/IyC6hvKyWpUU8tmTkK5b3BPNuMI9U8Sit+YAWLlZwB6Y6YrdCxfg2kNz05p3XY3Bmm4m26Nv3A==",
-      "dev": true,
-      "requires": {
-        "JSV": "^4.0.x",
-        "nomnom": "^1.5.x"
-      }
     },
     "locate-path": {
       "version": "3.0.0",
@@ -1058,24 +653,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-      "dev": true
-    },
-    "natural-compare": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.2.2.tgz",
-      "integrity": "sha1-H5bWDjFBysG20FZTzg2urHY69qo=",
-      "dev": true
-    },
-    "ncp": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
-      "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ=",
-      "dev": true
-    },
     "nock": {
       "version": "12.0.2",
       "resolved": "https://registry.npmjs.org/nock/-/nock-12.0.2.tgz",
@@ -1113,41 +690,6 @@
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
-      }
-    },
-    "nomnom": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-      "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
-      "dev": true,
-      "requires": {
-        "chalk": "~0.4.0",
-        "underscore": "~1.6.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "~1.0.0",
-            "has-color": "~0.1.0",
-            "strip-ansi": "~0.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
           "dev": true
         }
       }
@@ -1237,75 +779,17 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
-    "path-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-      "dev": true
-    },
-    "pathval": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-0.1.1.tgz",
-      "integrity": "sha1-CPkRzcqczllCiA2ngXvAtyO2bYI=",
-      "dev": true
-    },
     "picomatch": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
       "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
       "dev": true
     },
-    "pkginfo": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
-      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=",
-      "dev": true
-    },
-    "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-      "dev": true
-    },
-    "prompt": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
-      "integrity": "sha1-V3VPZPVD/XsIRXB8gY7OYY8F/9w=",
-      "dev": true,
-      "requires": {
-        "pkginfo": "0.x.x",
-        "read": "1.0.x",
-        "revalidator": "0.1.x",
-        "utile": "0.2.x",
-        "winston": "0.8.x"
-      }
-    },
     "propagate": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
       "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
       "dev": true
-    },
-    "read": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
-      "dev": true,
-      "requires": {
-        "mute-stream": "~0.0.4"
-      }
-    },
-    "readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-      "dev": true,
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
     },
     "readdirp": {
       "version": "3.2.0",
@@ -1315,12 +799,6 @@
       "requires": {
         "picomatch": "^2.0.4"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
     },
     "require-directory": {
       "version": "2.1.1",
@@ -1334,89 +812,16 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
-    "reserved-words": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.2.tgz",
-      "integrity": "sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE=",
-      "dev": true
-    },
-    "resolve": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
-      "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
-      "dev": true,
-      "requires": {
-        "path-parse": "^1.0.5"
-      }
-    },
-    "revalidator": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
-      "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs=",
-      "dev": true
-    },
-    "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.0.5"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
-      }
-    },
-    "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
-    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
-    "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
-    },
-    "source-map-support": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-      "dev": true,
-      "requires": {
-        "source-map": "^0.5.6"
-      }
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
-    },
-    "stack-trace": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "dev": true
     },
     "string-width": {
@@ -1466,48 +871,6 @@
         "function-bind": "^1.1.1"
       }
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
-    },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
-    },
-    "strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true,
-      "requires": {
-        "is-utf8": "^0.2.0"
-      }
-    },
-    "strip-json-comments": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
-      "dev": true
-    },
-    "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
-    },
-    "to-double-quotes": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-double-quotes/-/to-double-quotes-2.0.0.tgz",
-      "integrity": "sha1-qvIx1vqUiUn4GTAburRITYWI5Kc=",
-      "dev": true
-    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1517,92 +880,11 @@
         "is-number": "^7.0.0"
       }
     },
-    "to-single-quotes": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/to-single-quotes/-/to-single-quotes-2.0.1.tgz",
-      "integrity": "sha1-fMKRUfD18sQZRvEZ9ZMv5VQXASU=",
-      "dev": true
-    },
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
-    },
-    "underscore": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-      "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
-      "dev": true
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
-    },
-    "utile": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
-      "integrity": "sha1-kwyI6ZCY1iIINMNWy9mncFItkNc=",
-      "dev": true,
-      "requires": {
-        "async": "~0.2.9",
-        "deep-equal": "*",
-        "i": "0.3.x",
-        "mkdirp": "0.x.x",
-        "ncp": "0.4.x",
-        "rimraf": "2.x.x"
-      }
-    },
-    "uuid": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-      "dev": true
-    },
-    "vow": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.17.tgz",
-      "integrity": "sha512-A3/9bWFqf6gT0jLR4/+bT+IPTe1mQf+tdsW6+WI5geP9smAp8Kbbu4R6QQCDKZN/8TSCqTlXVQm12QliB4rHfg==",
-      "dev": true
-    },
-    "vow-fs": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.6.tgz",
-      "integrity": "sha1-LUxZviLivyYY3fWXq0uqkjvnIA0=",
-      "dev": true,
-      "requires": {
-        "glob": "^7.0.5",
-        "uuid": "^2.0.2",
-        "vow": "^0.4.7",
-        "vow-queue": "^0.4.1"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
-      }
-    },
-    "vow-queue": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.3.tgz",
-      "integrity": "sha512-/poAKDTFL3zYbeQg7cl4BGcfP4sGgXKrHnRFSKj97dteUFu8oyXMwIcdwu8NSx/RmPGIuYx1Bik/y5vU4H/VKw==",
-      "dev": true,
-      "requires": {
-        "vow": "^0.4.17"
-      }
     },
     "which": {
       "version": "1.3.1",
@@ -1626,35 +908,6 @@
       "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
-      }
-    },
-    "winston": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
-      "integrity": "sha1-ZLar9M0Brcrv1QCTk7HY6L7BnbA=",
-      "dev": true,
-      "requires": {
-        "async": "0.2.x",
-        "colors": "0.6.x",
-        "cycle": "1.0.x",
-        "eyes": "0.1.x",
-        "isstream": "0.1.x",
-        "pkginfo": "0.3.x",
-        "stack-trace": "0.0.x"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-          "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
-          "dev": true
-        },
-        "pkginfo": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
-          "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=",
-          "dev": true
-        }
       }
     },
     "wrap-ansi": {
@@ -1710,23 +963,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
-    },
-    "xmlbuilder": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-3.1.0.tgz",
-      "integrity": "sha1-LIaIjy1OrehQ+jjKf3Ij9yCVFuE=",
-      "dev": true,
-      "requires": {
-        "lodash": "^3.5.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        }
-      }
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "bugs:": "https://github.com/dnsimple/dnsimple-node/issues",
   "engines": {
-    "node": ">= v8.0.0"
+    "node": ">= v10.0.0"
   },
   "main": "lib/dnsimple.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {},
   "license": "MIT",
   "scripts": {
-    "test": "mocha --bail --recursive",
+    "test": "npm run lint && mocha --bail --recursive",
     "lint": "semistandard --verbose | snazzy"
   },
   "semistandard": {

--- a/package.json
+++ b/package.json
@@ -41,5 +41,11 @@
   "scripts": {
     "test": "mocha --bail --recursive",
     "lint": "semistandard --verbose | snazzy"
+  },
+  "semistandard": {
+    "globals": [
+      "describe",
+      "it"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
+    "eslint-config-standard": "^13.0.1",
     "js-yaml": ">=3.13.1",
     "lodash": ">=4.17.13",
     "mocha": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -32,11 +32,14 @@
     "js-yaml": ">=3.13.1",
     "lodash": ">=4.17.13",
     "mocha": "^7.1.0",
-    "nock": "^12.0.2"
+    "nock": "^12.0.2",
+    "semistandard": "^14.2.0",
+    "snazzy": "^8.0.0"
   },
   "dependencies": {},
   "license": "MIT",
   "scripts": {
-    "test": "mocha --bail --recursive"
+    "test": "mocha --bail --recursive",
+    "lint": "semistandard --verbose | snazzy"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "js-yaml": ">=3.13.1",
-    "jscs": "^3.0.7",
     "lodash": ">=4.17.13",
     "mocha": "^7.1.0",
     "nock": "^12.0.2"
@@ -38,7 +37,6 @@
   "dependencies": {},
   "license": "MIT",
   "scripts": {
-    "test": "npm run lint && mocha --bail --recursive",
-    "lint": "jscs ."
+    "test": "mocha --bail --recursive"
   }
 }

--- a/test/dnsimple.spec.js
+++ b/test/dnsimple.spec.js
@@ -7,24 +7,22 @@ var dnsimple = require('../lib/dnsimple')(
 
 var expect = require('chai').expect;
 
-describe('dnsimple module', function() {
-
-  describe('#setAccessToken', function() {
-    it('sets the access token', function() {
+describe('dnsimple module', function () {
+  describe('#setAccessToken', function () {
+    it('sets the access token', function () {
       dnsimple.setAccessToken('abc123');
       expect(dnsimple._api.accessToken).to.equal('abc123');
     });
   });
 
-  describe('#setUserAgent', function() {
-    it('respects the default User-Agent', function() {
+  describe('#setUserAgent', function () {
+    it('respects the default User-Agent', function () {
       expect(dnsimple._api.userAgent).to.equal('dnsimple-node/' + dnsimple.VERSION);
     });
 
-    it('composes the User-Agent', function() {
+    it('composes the User-Agent', function () {
       dnsimple.setUserAgent('my-app');
-      expect(dnsimple._api.userAgent).to.equal('my-app dnsimple-node/' +  dnsimple.VERSION);
+      expect(dnsimple._api.userAgent).to.equal('my-app dnsimple-node/' + dnsimple.VERSION);
     });
   });
-
 });

--- a/test/dnsimple/accounts.spec.js
+++ b/test/dnsimple/accounts.spec.js
@@ -2,29 +2,29 @@
 
 var testUtils = require('../testUtils');
 var dnsimple = require('../../lib/dnsimple')({
-  accessToken: testUtils.getAccessToken(),
+  accessToken: testUtils.getAccessToken()
 });
 
 const expect = require('chai').expect;
 const nock = require('nock');
 
-describe('accounts', function() {
-  describe('#listAccounts', function() {
+describe('accounts', function () {
+  describe('#listAccounts', function () {
     var fixture = testUtils.fixture('listAccounts/success-account.http');
 
-    it('produces an account list', function(done) {
+    it('produces an account list', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/accounts')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.accounts.listAccounts().then(function(response) {
+      dnsimple.accounts.listAccounts().then(function (response) {
         var accounts = response.data;
         expect(accounts.length).to.eq(1);
         expect(accounts[0].id).to.eq(123);
         expect(accounts[0].email).to.eq('john@example.com');
         expect(accounts[0].plan_identifier).to.eq('dnsimple-personal');
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });

--- a/test/dnsimple/certificates.spec.js
+++ b/test/dnsimple/certificates.spec.js
@@ -2,89 +2,89 @@
 
 var testUtils = require('../testUtils');
 var dnsimple = require('../../lib/dnsimple')({
-  accessToken: testUtils.getAccessToken(),
+  accessToken: testUtils.getAccessToken()
 });
 
 const expect = require('chai').expect;
 const nock = require('nock');
 
-describe('certificates', function() {
-  describe('#listCertificates', function() {
+describe('certificates', function () {
+  describe('#listCertificates', function () {
     var accountId = '1010';
     var domainId = 'example.com';
     var fixture = testUtils.fixture('listCertificates/success.http');
 
-    it('supports pagination', function(done) {
+    it('supports pagination', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/certificates?page=1')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.certificates.listCertificates(accountId, domainId, {page: 1});
+      dnsimple.certificates.listCertificates(accountId, domainId, { page: 1 });
 
       nock.isDone();
       done();
     });
 
-    it('supports extra request options', function(done) {
+    it('supports extra request options', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/certificates?foo=bar')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.certificates.listCertificates(accountId, domainId, {query: {foo: 'bar'}});
+      dnsimple.certificates.listCertificates(accountId, domainId, { query: { foo: 'bar' } });
 
       nock.isDone();
       done();
     });
 
-    it('supports sorting', function(done) {
+    it('supports sorting', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/certificates?sort=expires_on%3Aasc')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.certificates.listCertificates(accountId, domainId, {sort: 'expires_on:asc'});
+      dnsimple.certificates.listCertificates(accountId, domainId, { sort: 'expires_on:asc' });
 
       nock.isDone();
       done();
     });
 
-    it('produces a certificate list', function(done) {
+    it('produces a certificate list', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/certificates')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.certificates.listCertificates(accountId, domainId).then(function(response) {
+      dnsimple.certificates.listCertificates(accountId, domainId).then(function (response) {
         var certificates = response.data;
         expect(certificates.length).to.eq(2);
         expect(certificates[0].id).to.eq(1);
         expect(certificates[0].domain_id).to.eq(10);
         expect(certificates[0].common_name).to.eq('www.weppos.net');
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    it('exposes the pagination info', function(done) {
+    it('exposes the pagination info', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/certificates')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.certificates.listCertificates(accountId, domainId).then(function(response) {
+      dnsimple.certificates.listCertificates(accountId, domainId).then(function (response) {
         var pagination = response.pagination;
         expect(pagination).to.not.be.null;
         expect(pagination.current_page).to.eq(1);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#allCertificates', function() {
+  describe('#allCertificates', function () {
     var accountId = '1010';
-    var domainId = 'example.com'
+    var domainId = 'example.com';
 
-    it('produces a complete list', function(done) {
+    it('produces a complete list', function (done) {
       var fixture1 = testUtils.fixture('pages-1of3.http');
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/certificates?page=1')
@@ -100,31 +100,31 @@ describe('certificates', function() {
         .get('/v2/1010/domains/example.com/certificates?page=3')
         .reply(fixture3.statusCode, fixture3.body);
 
-      dnsimple.certificates.allCertificates(accountId, domainId).then(function(certificates) {
+      dnsimple.certificates.allCertificates(accountId, domainId).then(function (certificates) {
         expect(certificates.length).to.eq(5);
         expect(certificates[0].id).to.eq(1);
         expect(certificates[4].id).to.eq(5);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
-      }).catch(function(error) {
+      }).catch(function (error) {
         done(error);
       });
     });
   });
 
-  describe('#getCertificate', function() {
+  describe('#getCertificate', function () {
     var accountId = '1010';
     var domainId = 'example.com';
     var certificateId = 1;
     var fixture = testUtils.fixture('getCertificate/success.http');
 
-    it('produces a certificate', function(done) {
+    it('produces a certificate', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/certificates/1')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.certificates.getCertificate(accountId, domainId, certificateId).then(function(response) {
+      dnsimple.certificates.getCertificate(accountId, domainId, certificateId).then(function (response) {
         var certificate = response.data;
         expect(certificate.id).to.eq(1);
         expect(certificate.domain_id).to.eq(2);
@@ -134,21 +134,21 @@ describe('certificates', function() {
         expect(certificate.state).to.eq('issued');
         expect(certificate.expires_on).to.eq('2016-09-09');
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    describe('when the certificate does not exist', function() {
+    describe('when the certificate does not exist', function () {
       var fixture = testUtils.fixture('notfound-certificate.http');
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/certificates/0')
         .reply(fixture.statusCode, fixture.body);
 
-      it('produces an error', function(done) {
-        dnsimple.certificates.getCertificate(accountId, domainId, 0).then(function(response) {
+      it('produces an error', function (done) {
+        dnsimple.certificates.getCertificate(accountId, domainId, 0).then(function (response) {
           done();
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           expect(error.description).to.eq('Not found');
           expect(error.message).to.eq('Certificate `0` not found');
@@ -158,39 +158,39 @@ describe('certificates', function() {
     });
   });
 
-  describe('#downloadCertificate', function() {
+  describe('#downloadCertificate', function () {
     var accountId = '1010';
     var domainId = 'example.com';
     var certificateId = 1;
     var fixture = testUtils.fixture('downloadCertificate/success.http');
 
-    it('produces a certificate', function(done) {
+    it('produces a certificate', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/certificates/1/download')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.certificates.downloadCertificate(accountId, domainId, certificateId).then(function(response) {
+      dnsimple.certificates.downloadCertificate(accountId, domainId, certificateId).then(function (response) {
         var certificate = response.data;
         expect(certificate.server).to.match(/-----BEGIN CERTIFICATE-----/);
         expect(certificate.root).be.null;
         expect(certificate.chain.length).to.eq(1);
         expect(certificate.chain[0]).to.match(/-----BEGIN CERTIFICATE-----/);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    describe('when the certificate does not exist', function() {
+    describe('when the certificate does not exist', function () {
       var fixture = testUtils.fixture('notfound-certificate.http');
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/certificates/0/download')
         .reply(fixture.statusCode, fixture.body);
 
-      it('produces an error', function(done) {
-        dnsimple.certificates.downloadCertificate(accountId, domainId, 0).then(function(response) {
+      it('produces an error', function (done) {
+        dnsimple.certificates.downloadCertificate(accountId, domainId, 0).then(function (response) {
           done();
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           done();
         });
@@ -198,36 +198,36 @@ describe('certificates', function() {
     });
   });
 
-  describe('#getCertificatePrivateKey', function() {
+  describe('#getCertificatePrivateKey', function () {
     var accountId = '1010';
     var domainId = 'example.com';
     var certificateId = 1;
     var fixture = testUtils.fixture('getCertificatePrivateKey/success.http');
 
-    it('produces a certificate', function(done) {
+    it('produces a certificate', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/certificates/1/private_key')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.certificates.getCertificatePrivateKey(accountId, domainId, certificateId).then(function(response) {
+      dnsimple.certificates.getCertificatePrivateKey(accountId, domainId, certificateId).then(function (response) {
         var certificate = response.data;
         expect(certificate.private_key).to.match(/-----BEGIN RSA PRIVATE KEY-----/);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    describe('when the certificate does not exist', function() {
+    describe('when the certificate does not exist', function () {
       var fixture = testUtils.fixture('notfound-certificate.http');
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/certificates/0/private_key')
         .reply(fixture.statusCode, fixture.body);
 
-      it('produces an error', function(done) {
-        dnsimple.certificates.getCertificatePrivateKey(accountId, domainId, 0).then(function(response) {
+      it('produces an error', function (done) {
+        dnsimple.certificates.getCertificatePrivateKey(accountId, domainId, 0).then(function (response) {
           done();
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           done();
         });
@@ -235,93 +235,92 @@ describe('certificates', function() {
     });
   });
 
-  describe('#purchaseLetsencryptCertificate', function() {
+  describe('#purchaseLetsencryptCertificate', function () {
     var accountId = '1010';
     var domainId = 'example.com';
-    var attributes = {contact_id: 1}
+    var attributes = { contact_id: 1 };
     var fixture = testUtils.fixture('purchaseLetsencryptCertificate/success.http');
 
-    it('purchases a certificate', function(done) {
+    it('purchases a certificate', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/1010/domains/example.com/certificates/letsencrypt')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.certificates.purchaseLetsencryptCertificate(accountId, domainId, attributes).then(function(response) {
+      dnsimple.certificates.purchaseLetsencryptCertificate(accountId, domainId, attributes).then(function (response) {
         var certificate = response.data;
         expect(certificate.id).to.eq(300);
         done();
-      }, function(error) {
+      }, function (error) {
         done();
       });
     });
   });
 
-  describe('#issueLetsencryptCertificate', function() {
+  describe('#issueLetsencryptCertificate', function () {
     var accountId = '1010';
     var domainId = 'example.com';
     var certificateId = 200;
     var fixture = testUtils.fixture('issueLetsencryptCertificate/success.http');
 
-    it('issues a certificate', function(done) {
+    it('issues a certificate', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/1010/domains/example.com/certificates/200/issue')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.certificates.issueLetsencryptCertificate(accountId, domainId, certificateId).then(function(response) {
+      dnsimple.certificates.issueLetsencryptCertificate(accountId, domainId, certificateId).then(function (response) {
         var certificate = response.data;
         expect(certificate.id).to.eq(200);
         done();
-      }, function(error) {
+      }, function (error) {
         done();
       });
     });
   });
 
-  describe('#purchaseLetsencryptCertificateRenewal', function() {
+  describe('#purchaseLetsencryptCertificateRenewal', function () {
     var accountId = '1010';
     var domainId = 'example.com';
     var certificateId = 200;
     var fixture = testUtils.fixture('purchaseRenewalLetsencryptCertificate/success.http');
 
-    it('purchases a certificate renewal', function(done) {
+    it('purchases a certificate renewal', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/1010/domains/example.com/certificates/letsencrypt/200/renewal')
         .reply(fixture.statusCode, fixture.body);
 
       dnsimple.certificates.purchaseLetsencryptCertificateRenewal(accountId, domainId, certificateId)
-          .then(function(response) {
-        var certificateRenewal = response.data;
-        expect(certificateRenewal.id).to.eq(999);
-        expect(certificateRenewal.old_certificate_id).to.eq(certificateId);
-        expect(certificateRenewal.new_certificate_id).to.eq(300);
-        done();
-      }, function(error) {
-        done();
-      });
+        .then(function (response) {
+          var certificateRenewal = response.data;
+          expect(certificateRenewal.id).to.eq(999);
+          expect(certificateRenewal.old_certificate_id).to.eq(certificateId);
+          expect(certificateRenewal.new_certificate_id).to.eq(300);
+          done();
+        }, function (error) {
+          done();
+        });
     });
   });
 
-  describe('#issueLetsencryptCertificateRenewal', function() {
+  describe('#issueLetsencryptCertificateRenewal', function () {
     var accountId = '1010';
     var domainId = 'example.com';
     var certificateId = 200;
     var certificateRenewalId = 999;
     var fixture = testUtils.fixture('issueRenewalLetsencryptCertificate/success.http');
 
-    it('issues a certificate renewal', function(done) {
+    it('issues a certificate renewal', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/1010/domains/example.com/certificates/200/renewals/999/issue')
         .reply(fixture.statusCode, fixture.body);
 
       dnsimple.certificates.issueLetsencryptCertificateRenewal(accountId, domainId, certificateId, certificateRenewalId)
-          .then(function(response) {
-        var certificateRenewal = response.data;
-        expect(certificateRenewal.id).to.eq(999);
-        done();
-      }, function(error) {
-        done();
-      });
+        .then(function (response) {
+          var certificateRenewal = response.data;
+          expect(certificateRenewal.id).to.eq(999);
+          done();
+        }, function (error) {
+          done();
+        });
     });
-
   });
 });

--- a/test/dnsimple/certificates.spec.js
+++ b/test/dnsimple/certificates.spec.js
@@ -251,7 +251,7 @@ describe('certificates', function () {
         expect(certificate.id).to.eq(300);
         done();
       }, function (error) {
-        done();
+        done(error);
       });
     });
   });
@@ -264,15 +264,15 @@ describe('certificates', function () {
 
     it('issues a certificate', function (done) {
       nock('https://api.dnsimple.com')
-        .post('/v2/1010/domains/example.com/certificates/200/issue')
+        .post(`/v2/1010/domains/example.com/certificates/letsencrypt/${certificateId}/issue`)
         .reply(fixture.statusCode, fixture.body);
 
       dnsimple.certificates.issueLetsencryptCertificate(accountId, domainId, certificateId).then(function (response) {
         var certificate = response.data;
-        expect(certificate.id).to.eq(200);
+        expect(certificate.id).to.eq(certificateId);
         done();
       }, function (error) {
-        done();
+        done(error);
       });
     });
   });
@@ -285,7 +285,7 @@ describe('certificates', function () {
 
     it('purchases a certificate renewal', function (done) {
       nock('https://api.dnsimple.com')
-        .post('/v2/1010/domains/example.com/certificates/letsencrypt/200/renewal')
+        .post(`/v2/1010/domains/example.com/certificates/letsencrypt/${certificateId}/renewal`)
         .reply(fixture.statusCode, fixture.body);
 
       dnsimple.certificates.purchaseLetsencryptCertificateRenewal(accountId, domainId, certificateId)
@@ -296,7 +296,7 @@ describe('certificates', function () {
           expect(certificateRenewal.new_certificate_id).to.eq(300);
           done();
         }, function (error) {
-          done();
+          done(error);
         });
     });
   });
@@ -305,21 +305,21 @@ describe('certificates', function () {
     var accountId = '1010';
     var domainId = 'example.com';
     var certificateId = 200;
-    var certificateRenewalId = 999;
+    var certificateRenewalId = 300;
     var fixture = testUtils.fixture('issueRenewalLetsencryptCertificate/success.http');
 
     it('issues a certificate renewal', function (done) {
       nock('https://api.dnsimple.com')
-        .post('/v2/1010/domains/example.com/certificates/200/renewals/999/issue')
+        .post(`/v2/1010/domains/example.com/certificates/letsencrypt/${certificateId}/renewals/${certificateRenewalId}/issue`)
         .reply(fixture.statusCode, fixture.body);
 
       dnsimple.certificates.issueLetsencryptCertificateRenewal(accountId, domainId, certificateId, certificateRenewalId)
         .then(function (response) {
           var certificateRenewal = response.data;
-          expect(certificateRenewal.id).to.eq(999);
+          expect(certificateRenewal.id).to.eq(certificateRenewalId);
           done();
         }, function (error) {
-          done();
+          done(error);
         });
     });
   });

--- a/test/dnsimple/certificates.spec.js
+++ b/test/dnsimple/certificates.spec.js
@@ -305,7 +305,7 @@ describe('certificates', function () {
     var accountId = '1010';
     var domainId = 'example.com';
     var certificateId = 200;
-    var certificateRenewalId = 300;
+    var certificateRenewalId = 999;
     var fixture = testUtils.fixture('issueRenewalLetsencryptCertificate/success.http');
 
     it('issues a certificate renewal', function (done) {

--- a/test/dnsimple/certificates.spec.js
+++ b/test/dnsimple/certificates.spec.js
@@ -71,7 +71,7 @@ describe('certificates', function () {
 
       dnsimple.certificates.listCertificates(accountId, domainId).then(function (response) {
         var pagination = response.pagination;
-        expect(pagination).to.not.be.null;
+        expect(pagination).to.not.eq(null);
         expect(pagination.current_page).to.eq(1);
         done();
       }, function (error) {
@@ -149,7 +149,7 @@ describe('certificates', function () {
         dnsimple.certificates.getCertificate(accountId, domainId, 0).then(function (response) {
           done();
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           expect(error.description).to.eq('Not found');
           expect(error.message).to.eq('Certificate `0` not found');
           done();
@@ -172,7 +172,7 @@ describe('certificates', function () {
       dnsimple.certificates.downloadCertificate(accountId, domainId, certificateId).then(function (response) {
         var certificate = response.data;
         expect(certificate.server).to.match(/-----BEGIN CERTIFICATE-----/);
-        expect(certificate.root).be.null;
+        expect(certificate.root).to.eq(null);
         expect(certificate.chain.length).to.eq(1);
         expect(certificate.chain[0]).to.match(/-----BEGIN CERTIFICATE-----/);
         done();
@@ -191,7 +191,7 @@ describe('certificates', function () {
         dnsimple.certificates.downloadCertificate(accountId, domainId, 0).then(function (response) {
           done();
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           done();
         });
       });
@@ -228,7 +228,7 @@ describe('certificates', function () {
         dnsimple.certificates.getCertificatePrivateKey(accountId, domainId, 0).then(function (response) {
           done();
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           done();
         });
       });

--- a/test/dnsimple/client.spec.js
+++ b/test/dnsimple/client.spec.js
@@ -2,7 +2,7 @@
 
 const testUtils = require('../testUtils');
 const dnsimple = require('../../lib/dnsimple')({
-  accessToken: testUtils.getAccessToken(),
+  accessToken: testUtils.getAccessToken()
 });
 
 const Client = require('../../lib/dnsimple/client');
@@ -10,17 +10,17 @@ const Client = require('../../lib/dnsimple/client');
 const expect = require('chai').expect;
 const nock = require('nock');
 
-describe('response handling', function() {
-  describe('a 400 error', function() {
-    it('includes the error message from the server', function(done) {
-      let fixture = testUtils.fixture('validation-error.http');
+describe('response handling', function () {
+  describe('a 400 error', function () {
+    it('includes the error message from the server', function (done) {
+      const fixture = testUtils.fixture('validation-error.http');
       nock('https://api.dnsimple.com')
         .post('/v2/validation-error', {})
         .reply(fixture.statusCode, fixture.body);
 
-      new Client(dnsimple).post('/validation-error', {}, {}).then(function(response) {
+      new Client(dnsimple).post('/validation-error', {}, {}).then(function (response) {
         done('Expected error but promise resolved');
-      }, function(error) {
+      }, function (error) {
         expect(error.message).to.eq('Validation failed');
         expect(error.errors.email).to.include('can\'t be blank');
         done();
@@ -28,49 +28,48 @@ describe('response handling', function() {
     });
   });
 
-  describe('a 200 response with malformed json', function() {
-    it('produces a JSON parse error', function(done) {
-      let fixture = testUtils.fixture('success-with-malformed-json.http');
+  describe('a 200 response with malformed json', function () {
+    it('produces a JSON parse error', function (done) {
+      const fixture = testUtils.fixture('success-with-malformed-json.http');
       nock('https://api.dnsimple.com')
         .get('/v2/success-with-malformed-json')
         .reply(fixture.statusCode, fixture.body);
 
-      new Client(dnsimple).get('/success-with-malformed-json', {}).then(function(response) {
-
+      new Client(dnsimple).get('/success-with-malformed-json', {}).then(function (response) {
         done('Expected error but promise resolved');
-      }, function(error) {
+      }, function (error) {
         expect(error).to.eq('Unexpected token < in JSON at position 0');
         done();
       });
     });
   });
 
-  describe('an error response with HTML content', function() {
-    it('produces a JSON parse error', function(done) {
-      let fixture = testUtils.fixture('badgateway.http');
+  describe('an error response with HTML content', function () {
+    it('produces a JSON parse error', function (done) {
+      const fixture = testUtils.fixture('badgateway.http');
       nock('https://api.dnsimple.com')
         .get('/v2/badgateway')
         .reply(fixture.statusCode, fixture.body);
 
-      new Client(dnsimple).get('/badgateway', {}).then(function(response) {
+      new Client(dnsimple).get('/badgateway', {}).then(function (response) {
         done('Expected error but promise resolved');
-      }, function(error) {
+      }, function (error) {
         expect(error).to.eq('Unexpected token < in JSON at position 0');
         done();
       });
     });
   });
 
-  describe('a 405 error', function() {
-    it('results in a rejected promise', function(done) {
-      let fixture = testUtils.fixture('method-not-allowed.http');
+  describe('a 405 error', function () {
+    it('results in a rejected promise', function (done) {
+      const fixture = testUtils.fixture('method-not-allowed.http');
       nock('https://api.dnsimple.com')
         .get('/v2/method-not-allowed')
         .reply(fixture.statusCode, fixture.body);
 
-      new Client(dnsimple).get('/method-not-allowed', {}).then(function(response) {
+      new Client(dnsimple).get('/method-not-allowed', {}).then(function (response) {
         done('Expected error but promise resolved');
-      }, function(error) {
+      }, function (error) {
         expect(error.description).to.eq('Method not allowed');
         done();
       });

--- a/test/dnsimple/contacts.spec.js
+++ b/test/dnsimple/contacts.spec.js
@@ -82,7 +82,7 @@ describe('contacts', function () {
 
       dnsimple.contacts.listContacts(accountId).then(function (response) {
         var pagination = response.pagination;
-        expect(pagination).to.not.be.null;
+        expect(pagination).to.not.eq(null);
         expect(pagination.current_page).to.eq(1);
         done();
       }, function (error) {
@@ -156,7 +156,7 @@ describe('contacts', function () {
         dnsimple.contacts.getContact(accountId, '0').then(function (response) {
           done('Error expected but future resolved');
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           expect(error.description).to.eq('Not found');
           expect(error.message).to.eq('Contact `0` not found');
           done();
@@ -241,7 +241,7 @@ describe('contacts', function () {
         dnsimple.contacts.updateContact(accountId, '0', attributes).then(function (response) {
           done('Expected error but future resolved');
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           done();
         });
       });
@@ -287,7 +287,7 @@ describe('contacts', function () {
         dnsimple.contacts.deleteContact(accountId, '0').then(function (response) {
           done('Error expected but future resolved');
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           done();
         });
       });

--- a/test/dnsimple/contacts.spec.js
+++ b/test/dnsimple/contacts.spec.js
@@ -2,67 +2,67 @@
 
 var testUtils = require('../testUtils');
 var dnsimple = require('../../lib/dnsimple')({
-  accessToken: testUtils.getAccessToken(),
+  accessToken: testUtils.getAccessToken()
 });
 
 const expect = require('chai').expect;
 const nock = require('nock');
 
-describe('contacts', function() {
-  describe('#listContacts', function() {
+describe('contacts', function () {
+  describe('#listContacts', function () {
     var accountId = '1010';
     var fixture = testUtils.fixture('listContacts/success.http');
 
-    it('supports pagination', function(done) {
+    it('supports pagination', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/contacts?page=1')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.contacts.listContacts(accountId, {page: 1});
+      dnsimple.contacts.listContacts(accountId, { page: 1 });
 
       nock.isDone();
       done();
     });
 
-    it('supports extra request options', function(done) {
+    it('supports extra request options', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/contacts?foo=bar')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.contacts.listContacts(accountId, {query: {foo: 'bar'}});
+      dnsimple.contacts.listContacts(accountId, { query: { foo: 'bar' } });
 
       nock.isDone();
       done();
     });
 
-    it('supports sorting', function(done) {
+    it('supports sorting', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/contacts?sort=first_name%3Aasc')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.contacts.listContacts(accountId, {sort: 'first_name:asc'});
+      dnsimple.contacts.listContacts(accountId, { sort: 'first_name:asc' });
 
       nock.isDone();
       done();
     });
 
-    it('supports filter', function(done) {
+    it('supports filter', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/contacts?first_name_like=example')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.contacts.listContacts(accountId, {filter: {first_name_like: 'example'}});
+      dnsimple.contacts.listContacts(accountId, { filter: { first_name_like: 'example' } });
 
       nock.isDone();
       done();
     });
 
-    it('produces a contact list', function(done) {
+    it('produces a contact list', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/contacts')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.contacts.listContacts(accountId).then(function(response) {
+      dnsimple.contacts.listContacts(accountId).then(function (response) {
         var contacts = response.data;
         expect(contacts.length).to.eq(2);
         expect(contacts[0].account_id).to.eq(1010);
@@ -70,31 +70,31 @@ describe('contacts', function() {
         expect(contacts[0].first_name).to.eq('First');
         expect(contacts[0].last_name).to.eq('User');
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    it('exposes the pagination info', function(done) {
+    it('exposes the pagination info', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/contacts')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.contacts.listContacts(accountId).then(function(response) {
+      dnsimple.contacts.listContacts(accountId).then(function (response) {
         var pagination = response.pagination;
         expect(pagination).to.not.be.null;
         expect(pagination.current_page).to.eq(1);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#allContacts', function() {
+  describe('#allContacts', function () {
     var accountId = '1010';
 
-    it('produces a complete list', function(done) {
+    it('produces a complete list', function (done) {
       var fixture1 = testUtils.fixture('pages-1of3.http');
       nock('https://api.dnsimple.com')
         .get('/v2/1010/contacts?page=1')
@@ -110,29 +110,29 @@ describe('contacts', function() {
         .get('/v2/1010/contacts?page=3')
         .reply(fixture3.statusCode, fixture3.body);
 
-      dnsimple.contacts.allContacts(accountId).then(function(contacts) {
+      dnsimple.contacts.allContacts(accountId).then(function (contacts) {
         expect(contacts.length).to.eq(5);
         expect(contacts[0].id).to.eq(1);
         expect(contacts[4].id).to.eq(5);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
-      }).catch(function(error) {
+      }).catch(function (error) {
         done(error);
       });
     });
   });
 
-  describe('#getContact', function() {
+  describe('#getContact', function () {
     var accountId = '1010';
 
-    it('produces a contact', function(done) {
+    it('produces a contact', function (done) {
       var fixture = testUtils.fixture('getContact/success.http');
       nock('https://api.dnsimple.com')
         .get('/v2/1010/contacts/1')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.contacts.getContact(accountId, 1).then(function(response) {
+      dnsimple.contacts.getContact(accountId, 1).then(function (response) {
         var contact = response.data;
         expect(contact.id).to.eq(1);
         expect(contact.account_id).to.eq(1010);
@@ -140,22 +140,22 @@ describe('contacts', function() {
         expect(contact.first_name).to.eq('First');
         expect(contact.last_name).to.eq('User');
         done();
-      }, function(error) {
+      }, function (error) {
         console.log(error);
         done(error);
       });
     });
 
-    describe('when the contact does not exist', function() {
-      it('produces an error', function(done) {
+    describe('when the contact does not exist', function () {
+      it('produces an error', function (done) {
         var fixture = testUtils.fixture('notfound-contact.http');
         nock('https://api.dnsimple.com')
           .get('/v2/1010/contacts/0')
           .reply(fixture.statusCode, fixture.body);
 
-        dnsimple.contacts.getContact(accountId, '0').then(function(response) {
+        dnsimple.contacts.getContact(accountId, '0').then(function (response) {
           done('Error expected but future resolved');
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           expect(error.description).to.eq('Not found');
           expect(error.message).to.eq('Contact `0` not found');
@@ -165,12 +165,12 @@ describe('contacts', function() {
     });
   });
 
-  describe('#createContact', function() {
+  describe('#createContact', function () {
     var accountId = '1010';
-    var attributes = {first_name: 'John', last_name: 'Smith'};
+    var attributes = { first_name: 'John', last_name: 'Smith' };
     var fixture = testUtils.fixture('createContact/created.http');
 
-    it('builds the correct request', function(done) {
+    it('builds the correct request', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/1010/contacts', attributes)
         .reply(fixture.statusCode, fixture.body);
@@ -181,12 +181,12 @@ describe('contacts', function() {
       done();
     });
 
-    it('produces a contact', function(done) {
+    it('produces a contact', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/1010/contacts', attributes)
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.contacts.createContact(accountId, attributes).then(function(response) {
+      dnsimple.contacts.createContact(accountId, attributes).then(function (response) {
         var contact = response.data;
         expect(contact.id).to.eq(1);
         expect(contact.account_id).to.eq(1010);
@@ -194,19 +194,19 @@ describe('contacts', function() {
         expect(contact.first_name).to.eq('First');
         expect(contact.last_name).to.eq('User');
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#updateContact', function() {
+  describe('#updateContact', function () {
     var accountId = '1010';
     var contactId = 1;
-    var attributes = {last_name: 'Buckminster'};
+    var attributes = { last_name: 'Buckminster' };
     var fixture = testUtils.fixture('updateContact/success.http');
 
-    it('builds the correct request', function(done) {
+    it('builds the correct request', function (done) {
       nock('https://api.dnsimple.com')
         .patch('/v2/1010/contacts/' + contactId, attributes)
         .reply(fixture.statusCode, fixture.body);
@@ -217,30 +217,30 @@ describe('contacts', function() {
       done();
     });
 
-    it('produces a contact', function(done) {
+    it('produces a contact', function (done) {
       nock('https://api.dnsimple.com')
         .patch('/v2/1010/contacts/' + contactId, attributes)
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.contacts.updateContact(accountId, contactId, attributes).then(function(response) {
+      dnsimple.contacts.updateContact(accountId, contactId, attributes).then(function (response) {
         var contact = response.data;
         expect(contact.id).to.eq(1);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    describe('when the contact does not exist', function() {
+    describe('when the contact does not exist', function () {
       var fixture = testUtils.fixture('notfound-contact.http');
       nock('https://api.dnsimple.com')
         .get('/v2/1010/contacts/0', attributes)
         .reply(fixture.statusCode, fixture.body);
 
-      it('produces an error', function(done) {
-        dnsimple.contacts.updateContact(accountId, '0', attributes).then(function(response) {
+      it('produces an error', function (done) {
+        dnsimple.contacts.updateContact(accountId, '0', attributes).then(function (response) {
           done('Expected error but future resolved');
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           done();
         });
@@ -248,12 +248,12 @@ describe('contacts', function() {
     });
   });
 
-  describe('#deleteContact', function() {
+  describe('#deleteContact', function () {
     var accountId = '1010';
     var contactId = 1;
     var fixture = testUtils.fixture('deleteContact/success.http');
 
-    it('builds the correct request', function(done) {
+    it('builds the correct request', function (done) {
       nock('https://api.dnsimple.com')
         .delete('/v2/1010/contacts/' + contactId)
         .reply(fixture.statusCode, fixture.body);
@@ -264,34 +264,33 @@ describe('contacts', function() {
       done();
     });
 
-    it('produces nothing', function(done) {
+    it('produces nothing', function (done) {
       nock('https://api.dnsimple.com')
         .delete('/v2/1010/contacts/' + contactId)
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.contacts.deleteContact(accountId, contactId).then(function(response) {
+      dnsimple.contacts.deleteContact(accountId, contactId).then(function (response) {
         expect(response).to.eql({});
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    describe('when the contact does not exist', function() {
-      it('produces an error', function(done) {
+    describe('when the contact does not exist', function () {
+      it('produces an error', function (done) {
         var fixture = testUtils.fixture('notfound-contact.http');
         nock('https://api.dnsimple.com')
           .delete('/v2/1010/contacts/0')
           .reply(fixture.statusCode, fixture.body);
 
-        dnsimple.contacts.deleteContact(accountId, '0').then(function(response) {
+        dnsimple.contacts.deleteContact(accountId, '0').then(function (response) {
           done('Error expected but future resolved');
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           done();
         });
       });
     });
   });
-
 });

--- a/test/dnsimple/domain_collaborators.spec.js
+++ b/test/dnsimple/domain_collaborators.spec.js
@@ -60,7 +60,7 @@ describe('collaborators', function () {
 
       dnsimple.domains.listCollaborators(accountId, domainId).then(function (response) {
         var pagination = response.pagination;
-        expect(pagination).to.not.be.null;
+        expect(pagination).to.not.eq(null);
         expect(pagination.current_page).to.eq(1);
         done();
       }, function (error) {

--- a/test/dnsimple/domain_collaborators.spec.js
+++ b/test/dnsimple/domain_collaborators.spec.js
@@ -2,114 +2,114 @@
 
 var testUtils = require('../testUtils');
 var dnsimple = require('../../lib/dnsimple')({
-  accessToken: testUtils.getAccessToken(),
+  accessToken: testUtils.getAccessToken()
 });
 
 const expect = require('chai').expect;
 const nock = require('nock');
 
-describe('collaborators', function() {
-  describe('#listCollaborators', function() {
+describe('collaborators', function () {
+  describe('#listCollaborators', function () {
     var accountId = '1010';
     var domainId = 'example.com';
     var fixture = testUtils.fixture('listCollaborators/success.http');
 
-    it('supports pagination', function(done) {
+    it('supports pagination', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/collaborators?page=1')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.listCollaborators(accountId, domainId, {page: 1});
+      dnsimple.domains.listCollaborators(accountId, domainId, { page: 1 });
 
       nock.isDone();
       done();
     });
 
-    it('supports extra request options', function(done) {
+    it('supports extra request options', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/collaborators?foo=bar')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.listCollaborators(accountId, domainId, {query: {foo: 'bar'}});
+      dnsimple.domains.listCollaborators(accountId, domainId, { query: { foo: 'bar' } });
 
       nock.isDone();
       done();
     });
 
-    it('produces a collaborators list', function(done) {
+    it('produces a collaborators list', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/collaborators')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.listCollaborators(accountId, domainId).then(function(response) {
+      dnsimple.domains.listCollaborators(accountId, domainId).then(function (response) {
         var collaborators = response.data;
         expect(collaborators.length).to.eq(2);
         expect(collaborators[0].id).to.eq(100);
         expect(collaborators[0].domain_id).to.eq(1);
         expect(collaborators[0].user_id).to.eq(999);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    it('exposes the pagination info', function(done) {
+    it('exposes the pagination info', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/collaborators')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.listCollaborators(accountId, domainId).then(function(response) {
+      dnsimple.domains.listCollaborators(accountId, domainId).then(function (response) {
         var pagination = response.pagination;
         expect(pagination).to.not.be.null;
         expect(pagination.current_page).to.eq(1);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#addCollaborator', function() {
+  describe('#addCollaborator', function () {
     var accountId = '1010';
     var domainId = 'example.com';
     var collaborator = {
-      email: 'existing-user@example.com',
+      email: 'existing-user@example.com'
     };
 
-    it('produces a response', function(done) {
+    it('produces a response', function (done) {
       var fixture = testUtils.fixture('addCollaborator/success.http');
 
       nock('https://api.dnsimple.com')
         .post('/v2/1010/domains/example.com/collaborators')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.addCollaborator(accountId, domainId, collaborator).then(function(response) {
+      dnsimple.domains.addCollaborator(accountId, domainId, collaborator).then(function (response) {
         var data = response.data;
         expect(data.id).to.eql(100);
         expect(data.invitation).to.eql(false);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#removeCollaborator', function() {
+  describe('#removeCollaborator', function () {
     var accountId = '1010';
     var domainId = 'example.com';
     var collaboratorId = '100';
 
-    it('produces nothing', function(done) {
+    it('produces nothing', function (done) {
       var fixture = testUtils.fixture('removeCollaborator/success.http');
 
       nock('https://api.dnsimple.com')
         .delete('/v2/1010/domains/example.com/collaborators/100')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.removeCollaborator(accountId, domainId, collaboratorId).then(function(response) {
+      dnsimple.domains.removeCollaborator(accountId, domainId, collaboratorId).then(function (response) {
         expect(response).to.eql({});
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });

--- a/test/dnsimple/domain_delegation_signer_records_spec.js
+++ b/test/dnsimple/domain_delegation_signer_records_spec.js
@@ -2,86 +2,86 @@
 
 var testUtils = require('../testUtils');
 var dnsimple = require('../../lib/dnsimple')({
-  accessToken: testUtils.getAccessToken(),
+  accessToken: testUtils.getAccessToken()
 });
 
 const expect = require('chai').expect;
 const nock = require('nock');
 
-describe('domains', function() {
-  describe('#listDelegationSignerRecords', function() {
+describe('domains', function () {
+  describe('#listDelegationSignerRecords', function () {
     var accountId = '1010';
     var domainId = 'example.com';
     var fixture = testUtils.fixture('listDelegationSignerRecords/success.http');
 
-    it('supports pagination', function(done) {
+    it('supports pagination', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/ds_records?page=1')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.listDelegationSignerRecords(accountId, domainId, {page: 1});
+      dnsimple.domains.listDelegationSignerRecords(accountId, domainId, { page: 1 });
 
       nock.isDone();
       done();
     });
 
-    it('supports extra request options', function(done) {
+    it('supports extra request options', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/ds_records?foo=bar')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.listDelegationSignerRecords(accountId, domainId, {query: {foo: 'bar'}});
+      dnsimple.domains.listDelegationSignerRecords(accountId, domainId, { query: { foo: 'bar' } });
 
       nock.isDone();
       done();
     });
 
-    it('supports sorting', function(done) {
+    it('supports sorting', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/ds_records?sort=from%3Aasc')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.listDelegationSignerRecords(accountId, domainId, {sort: 'from:asc'});
+      dnsimple.domains.listDelegationSignerRecords(accountId, domainId, { sort: 'from:asc' });
 
       nock.isDone();
       done();
     });
 
-    it('produces an delegation signer records list', function(done) {
+    it('produces an delegation signer records list', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/ds_records')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.listDelegationSignerRecords(accountId, domainId).then(function(response) {
+      dnsimple.domains.listDelegationSignerRecords(accountId, domainId).then(function (response) {
         var dsRecords = response.data;
         expect(dsRecords.length).to.eq(1);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    it('exposes the pagination info', function(done) {
+    it('exposes the pagination info', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/ds_records')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.listDelegationSignerRecords(accountId, domainId).then(function(response) {
+      dnsimple.domains.listDelegationSignerRecords(accountId, domainId).then(function (response) {
         var pagination = response.pagination;
         expect(pagination).to.not.be.null;
         expect(pagination.current_page).to.eq(1);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#allDelegationSignerRecords', function() {
+  describe('#allDelegationSignerRecords', function () {
     var accountId = '1010';
-    var domainId = 'example.com'
+    var domainId = 'example.com';
 
-    it('produces a complete list', function(done) {
+    it('produces a complete list', function (done) {
       var fixture1 = testUtils.fixture('pages-1of3.http');
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/ds_records?page=1')
@@ -97,31 +97,31 @@ describe('domains', function() {
         .get('/v2/1010/domains/example.com/ds_records?page=3')
         .reply(fixture3.statusCode, fixture3.body);
 
-      dnsimple.domains.allDelegationSignerRecords(accountId, domainId).then(function(items) {
+      dnsimple.domains.allDelegationSignerRecords(accountId, domainId).then(function (items) {
         expect(items.length).to.eq(5);
         expect(items[0].id).to.eq(1);
         expect(items[4].id).to.eq(5);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
-      }).catch(function(error) {
+      }).catch(function (error) {
         done(error);
       });
     });
   });
 
-  describe('#getDelegationSignerRecord', function() {
+  describe('#getDelegationSignerRecord', function () {
     var accountId = '1010';
     var domainId = 'example.com';
     var dsRecordId = 1;
     var fixture = testUtils.fixture('getDelegationSignerRecord/success.http');
 
-    it('produces a delegation signer record', function(done) {
+    it('produces a delegation signer record', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/ds_records/1')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.getDelegationSignerRecord(accountId, domainId, dsRecordId).then(function(response) {
+      dnsimple.domains.getDelegationSignerRecord(accountId, domainId, dsRecordId).then(function (response) {
         var dsRecord = response.data;
         expect(dsRecord.id).to.eq(24);
         expect(dsRecord.algorithm).to.eq('8');
@@ -131,21 +131,21 @@ describe('domains', function() {
         expect(dsRecord.created_at).to.eq('2017-03-03T13:49:58Z');
         expect(dsRecord.updated_at).to.eq('2017-03-03T13:49:58Z');
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    describe('when the delegation signer record does not exist', function() {
+    describe('when the delegation signer record does not exist', function () {
       var fixture = testUtils.fixture('notfound-delegationSignerRecord.http');
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/ds_records/0')
         .reply(fixture.statusCode, fixture.body);
 
-      it('produces an error', function(done) {
-        dnsimple.domains.getDelegationSignerRecord(accountId, domainId, 0).then(function(response) {
+      it('produces an error', function (done) {
+        dnsimple.domains.getDelegationSignerRecord(accountId, domainId, 0).then(function (response) {
           done();
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           expect(error.description).to.eq('Not found');
           expect(error.message).to.eq('Delegation signer record `0` not found');
@@ -155,13 +155,13 @@ describe('domains', function() {
     });
   });
 
-  describe('#createDelegationSignerRecord', function() {
+  describe('#createDelegationSignerRecord', function () {
     var accountId = '1010';
     var domainId = 'example.com';
-    var attributes = {algorithm: '8'};
+    var attributes = { algorithm: '8' };
     var fixture = testUtils.fixture('createDelegationSignerRecord/created.http');
 
-    it('builds the correct request', function(done) {
+    it('builds the correct request', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/1010/domains/example.com/ds_records', attributes)
         .reply(fixture.statusCode, fixture.body);
@@ -172,36 +172,36 @@ describe('domains', function() {
       done();
     });
 
-    it('produces a delegation signer record', function(done) {
+    it('produces a delegation signer record', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/1010/domains/example.com/ds_records')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.createDelegationSignerRecord(accountId, domainId, attributes).then(function(response) {
+      dnsimple.domains.createDelegationSignerRecord(accountId, domainId, attributes).then(function (response) {
         var dsRecord = response.data;
         expect(dsRecord.id).to.eq(2);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#deleteDelegationSignerRecord', function() {
+  describe('#deleteDelegationSignerRecord', function () {
     var accountId = '1010';
     var domainId = 'example.com';
     var dsRecordId = 1;
     var fixture = testUtils.fixture('deleteDelegationSignerRecord/success.http');
 
-    it('produces nothing', function(done) {
+    it('produces nothing', function (done) {
       nock('https://api.dnsimple.com')
         .delete('/v2/1010/domains/example.com/ds_records/1')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.deleteDelegationSignerRecord(accountId, domainId, dsRecordId).then(function(response) {
+      dnsimple.domains.deleteDelegationSignerRecord(accountId, domainId, dsRecordId).then(function (response) {
         expect(response).to.eql({});
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });

--- a/test/dnsimple/domain_delegation_signer_records_spec.js
+++ b/test/dnsimple/domain_delegation_signer_records_spec.js
@@ -68,7 +68,7 @@ describe('domains', function () {
 
       dnsimple.domains.listDelegationSignerRecords(accountId, domainId).then(function (response) {
         var pagination = response.pagination;
-        expect(pagination).to.not.be.null;
+        expect(pagination).to.not.eq(null);
         expect(pagination.current_page).to.eq(1);
         done();
       }, function (error) {
@@ -146,7 +146,7 @@ describe('domains', function () {
         dnsimple.domains.getDelegationSignerRecord(accountId, domainId, 0).then(function (response) {
           done();
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           expect(error.description).to.eq('Not found');
           expect(error.message).to.eq('Delegation signer record `0` not found');
           done();

--- a/test/dnsimple/domain_dnssec_spec.js
+++ b/test/dnsimple/domain_dnssec_spec.js
@@ -32,7 +32,7 @@ describe('domains', function () {
 
       dnsimple.domains.enableDnssec(accountId, domainId).then(function (response) {
         var dnssec = response.data;
-        expect(dnssec.enabled).to.be.true;
+        expect(dnssec.enabled).to.eq(true);
         done();
       }, function (error) {
         done(error);
@@ -82,7 +82,7 @@ describe('domains', function () {
 
       dnsimple.domains.getDnssec(accountId, domainId).then(function (response) {
         var dnssec = response.data;
-        expect(dnssec.enabled).to.be.true;
+        expect(dnssec.enabled).to.eq(true);
         done();
       }, function (error) {
         done(error);

--- a/test/dnsimple/domain_dnssec_spec.js
+++ b/test/dnsimple/domain_dnssec_spec.js
@@ -2,19 +2,19 @@
 
 var testUtils = require('../testUtils');
 var dnsimple = require('../../lib/dnsimple')({
-  accessToken: testUtils.getAccessToken(),
+  accessToken: testUtils.getAccessToken()
 });
 
 const expect = require('chai').expect;
 const nock = require('nock');
 
-describe('domains', function() {
-  describe('#enableDnssec', function() {
+describe('domains', function () {
+  describe('#enableDnssec', function () {
     var accountId = '1010';
     var domainId = 'example.com';
     var fixture = testUtils.fixture('enableDnssec/success.http');
 
-    it('builds the correct request', function(done) {
+    it('builds the correct request', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/1010/domains/example.com/dnssec')
         .reply(fixture.statusCode, fixture.body);
@@ -25,46 +25,46 @@ describe('domains', function() {
       done();
     });
 
-    it('produces an response', function(done) {
+    it('produces an response', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/1010/domains/example.com/dnssec')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.enableDnssec(accountId, domainId).then(function(response) {
+      dnsimple.domains.enableDnssec(accountId, domainId).then(function (response) {
         var dnssec = response.data;
         expect(dnssec.enabled).to.be.true;
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#disableDnssec', function() {
+  describe('#disableDnssec', function () {
     var accountId = '1010';
     var domainId = 'example.com';
     var fixture = testUtils.fixture('disableDnssec/success.http');
 
-    it('produces nothing', function(done) {
+    it('produces nothing', function (done) {
       nock('https://api.dnsimple.com')
         .delete('/v2/1010/domains/example.com/dnssec')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.disableDnssec(accountId, domainId).then(function(response) {
+      dnsimple.domains.disableDnssec(accountId, domainId).then(function (response) {
         expect(response).to.eql({});
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#getDnssec', function() {
+  describe('#getDnssec', function () {
     var accountId = '1010';
     var domainId = 'example.com';
     var fixture = testUtils.fixture('getDnssec/success.http');
 
-    it('builds the correct request', function(done) {
+    it('builds the correct request', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/dnssec')
         .reply(fixture.statusCode, fixture.body);
@@ -75,19 +75,18 @@ describe('domains', function() {
       done();
     });
 
-    it('produces an response', function(done) {
+    it('produces an response', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/dnssec')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.getDnssec(accountId, domainId).then(function(response) {
+      dnsimple.domains.getDnssec(accountId, domainId).then(function (response) {
         var dnssec = response.data;
         expect(dnssec.enabled).to.be.true;
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 });
-

--- a/test/dnsimple/domain_email_forwards.spec.js
+++ b/test/dnsimple/domain_email_forwards.spec.js
@@ -68,7 +68,7 @@ describe('domains', function () {
 
       dnsimple.domains.listEmailForwards(accountId, domainId).then(function (response) {
         var pagination = response.pagination;
-        expect(pagination).to.not.be.null;
+        expect(pagination).to.not.eq(null);
         expect(pagination.current_page).to.eq(1);
         done();
       }, function (error) {
@@ -145,7 +145,7 @@ describe('domains', function () {
         dnsimple.domains.getEmailForward(accountId, domainId, 0).then(function (response) {
           done();
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           expect(error.description).to.eq('Not found');
           expect(error.message).to.eq('Email forward `0` not found');
           done();

--- a/test/dnsimple/domain_email_forwards.spec.js
+++ b/test/dnsimple/domain_email_forwards.spec.js
@@ -2,86 +2,86 @@
 
 var testUtils = require('../testUtils');
 var dnsimple = require('../../lib/dnsimple')({
-  accessToken: testUtils.getAccessToken(),
+  accessToken: testUtils.getAccessToken()
 });
 
 const expect = require('chai').expect;
 const nock = require('nock');
 
-describe('domains', function() {
-  describe('#listEmailForwards', function() {
+describe('domains', function () {
+  describe('#listEmailForwards', function () {
     var accountId = '1010';
     var domainId = 'example.com';
     var fixture = testUtils.fixture('listEmailForwards/success.http');
 
-    it('supports pagination', function(done) {
+    it('supports pagination', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/email_forwards?page=1')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.listEmailForwards(accountId, domainId, {page: 1});
+      dnsimple.domains.listEmailForwards(accountId, domainId, { page: 1 });
 
       nock.isDone();
       done();
     });
 
-    it('supports extra request options', function(done) {
+    it('supports extra request options', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/email_forwards?foo=bar')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.listEmailForwards(accountId, domainId, {query: {foo: 'bar'}});
+      dnsimple.domains.listEmailForwards(accountId, domainId, { query: { foo: 'bar' } });
 
       nock.isDone();
       done();
     });
 
-    it('supports sorting', function(done) {
+    it('supports sorting', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/email_forwards?sort=from%3Aasc')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.listEmailForwards(accountId, domainId, {sort: 'from:asc'});
+      dnsimple.domains.listEmailForwards(accountId, domainId, { sort: 'from:asc' });
 
       nock.isDone();
       done();
     });
 
-    it('produces an email forward list', function(done) {
+    it('produces an email forward list', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/email_forwards')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.listEmailForwards(accountId, domainId).then(function(response) {
+      dnsimple.domains.listEmailForwards(accountId, domainId).then(function (response) {
         var emailForwards = response.data;
         expect(emailForwards.length).to.eq(2);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    it('exposes the pagination info', function(done) {
+    it('exposes the pagination info', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/email_forwards')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.listEmailForwards(accountId, domainId).then(function(response) {
+      dnsimple.domains.listEmailForwards(accountId, domainId).then(function (response) {
         var pagination = response.pagination;
         expect(pagination).to.not.be.null;
         expect(pagination.current_page).to.eq(1);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#allEmailForwards', function() {
+  describe('#allEmailForwards', function () {
     var accountId = '1010';
-    var domainId = 'example.com'
+    var domainId = 'example.com';
 
-    it('produces a complete list', function(done) {
+    it('produces a complete list', function (done) {
       var fixture1 = testUtils.fixture('pages-1of3.http');
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/email_forwards?page=1')
@@ -97,31 +97,31 @@ describe('domains', function() {
         .get('/v2/1010/domains/example.com/email_forwards?page=3')
         .reply(fixture3.statusCode, fixture3.body);
 
-      dnsimple.domains.allEmailForwards(accountId, domainId).then(function(items) {
+      dnsimple.domains.allEmailForwards(accountId, domainId).then(function (items) {
         expect(items.length).to.eq(5);
         expect(items[0].id).to.eq(1);
         expect(items[4].id).to.eq(5);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
-      }).catch(function(error) {
+      }).catch(function (error) {
         done(error);
       });
     });
   });
 
-  describe('#getEmailForward', function() {
+  describe('#getEmailForward', function () {
     var accountId = '1010';
     var domainId = 'example.com';
     var emailForwardId = 1;
     var fixture = testUtils.fixture('getEmailForward/success.http');
 
-    it('produces an email forward', function(done) {
+    it('produces an email forward', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/email_forwards/1')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.getEmailForward(accountId, domainId, emailForwardId).then(function(response) {
+      dnsimple.domains.getEmailForward(accountId, domainId, emailForwardId).then(function (response) {
         var emailForward = response.data;
         expect(emailForward.id).to.eq(17706);
         expect(emailForward.domain_id).to.eq(228963);
@@ -130,21 +130,21 @@ describe('domains', function() {
         expect(emailForward.created_at).to.eq('2016-02-04T14:26:50Z');
         expect(emailForward.updated_at).to.eq('2016-02-04T14:26:50Z');
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    describe('when the email forward does not exist', function() {
+    describe('when the email forward does not exist', function () {
       var fixture = testUtils.fixture('notfound-emailforward.http');
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/email_forwards/0')
         .reply(fixture.statusCode, fixture.body);
 
-      it('produces an error', function(done) {
-        dnsimple.domains.getEmailForward(accountId, domainId, 0).then(function(response) {
+      it('produces an error', function (done) {
+        dnsimple.domains.getEmailForward(accountId, domainId, 0).then(function (response) {
           done();
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           expect(error.description).to.eq('Not found');
           expect(error.message).to.eq('Email forward `0` not found');
@@ -154,13 +154,13 @@ describe('domains', function() {
     });
   });
 
-  describe('#createEmailForward', function() {
+  describe('#createEmailForward', function () {
     var accountId = '1010';
     var domainId = 'example.com';
-    var attributes = {from: 'jim'};
+    var attributes = { from: 'jim' };
     var fixture = testUtils.fixture('createEmailForward/created.http');
 
-    it('builds the correct request', function(done) {
+    it('builds the correct request', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/1010/domains/example.com/email_forwards', attributes)
         .reply(fixture.statusCode, fixture.body);
@@ -171,36 +171,36 @@ describe('domains', function() {
       done();
     });
 
-    it('produces an email forward', function(done) {
+    it('produces an email forward', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/1010/domains/example.com/email_forwards')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.createEmailForward(accountId, domainId, attributes).then(function(response) {
+      dnsimple.domains.createEmailForward(accountId, domainId, attributes).then(function (response) {
         var emailForward = response.data;
         expect(emailForward.id).to.eq(17706);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#deleteEmailForward', function() {
+  describe('#deleteEmailForward', function () {
     var accountId = '1010';
     var domainId = 'example.com';
     var emailForwardId = 1;
     var fixture = testUtils.fixture('deleteEmailForward/success.http');
 
-    it('produces nothing', function(done) {
+    it('produces nothing', function (done) {
       nock('https://api.dnsimple.com')
         .delete('/v2/1010/domains/example.com/email_forwards/1')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.deleteEmailForward(accountId, domainId, emailForwardId).then(function(response) {
+      dnsimple.domains.deleteEmailForward(accountId, domainId, emailForwardId).then(function (response) {
         expect(response).to.eql({});
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });

--- a/test/dnsimple/domain_pushes.spec.js
+++ b/test/dnsimple/domain_pushes.spec.js
@@ -2,20 +2,20 @@
 
 var testUtils = require('../testUtils');
 var dnsimple = require('../../lib/dnsimple')({
-  accessToken: testUtils.getAccessToken(),
+  accessToken: testUtils.getAccessToken()
 });
 
 const expect = require('chai').expect;
 const nock = require('nock');
 
-describe('domains', function() {
-  describe('#initiatePush', function() {
+describe('domains', function () {
+  describe('#initiatePush', function () {
     var accountId = '1010';
     var domainId = 'example.com';
-    var attributes = {new_account_email: 'jim@example.com'};
+    var attributes = { new_account_email: 'jim@example.com' };
     var fixture = testUtils.fixture('initiatePush/success.http');
 
-    it('builds the correct request', function(done) {
+    it('builds the correct request', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/1010/domains/example.com/pushes', attributes)
         .reply(fixture.statusCode, fixture.body);
@@ -26,12 +26,12 @@ describe('domains', function() {
       done();
     });
 
-    it('produces a push result', function(done) {
+    it('produces a push result', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/1010/domains/example.com/pushes')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.initiatePush(accountId, domainId, attributes).then(function(response) {
+      dnsimple.domains.initiatePush(accountId, domainId, attributes).then(function (response) {
         var push = response.data;
         expect(push.id).to.eq(1);
         expect(push.domain_id).to.eq(100);
@@ -41,38 +41,38 @@ describe('domains', function() {
         expect(push.updated_at).to.eq('2016-08-11T10:16:03Z');
         expect(push.accepted_at).to.be.null;
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#listPushes', function() {
+  describe('#listPushes', function () {
     var accountId = '1010';
     var fixture = testUtils.fixture('listPushes/success.http');
 
-    it('produces an pushes list', function(done) {
+    it('produces an pushes list', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/pushes')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.listPushes(accountId).then(function(response) {
+      dnsimple.domains.listPushes(accountId).then(function (response) {
         var pushes = response.data;
         expect(pushes.length).to.eq(2);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#acceptPush', function() {
+  describe('#acceptPush', function () {
     var accountId = '1010';
     var pushId = '200';
-    var attributes = {contact_id: 1};
+    var attributes = { contact_id: 1 };
     var fixture = testUtils.fixture('acceptPush/success.http');
 
-    it('builds the correct request', function(done) {
+    it('builds the correct request', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/1010/pushes/200', attributes)
         .reply(fixture.statusCode, fixture.body);
@@ -83,26 +83,26 @@ describe('domains', function() {
       done();
     });
 
-    it('produces nothing', function(done) {
+    it('produces nothing', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/1010/pushes/200')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.acceptPush(accountId, pushId, attributes).then(function(response) {
+      dnsimple.domains.acceptPush(accountId, pushId, attributes).then(function (response) {
         expect(response).to.eql({});
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#rejectPush', function() {
+  describe('#rejectPush', function () {
     var accountId = '1010';
     var pushId = '200';
     var fixture = testUtils.fixture('rejectPush/success.http');
 
-    it('builds the correct request', function(done) {
+    it('builds the correct request', function (done) {
       nock('https://api.dnsimple.com')
         .delete('/v2/1010/pushes/200')
         .reply(fixture.statusCode, fixture.body);
@@ -113,15 +113,15 @@ describe('domains', function() {
       done();
     });
 
-    it('produces nothing', function(done) {
+    it('produces nothing', function (done) {
       nock('https://api.dnsimple.com')
         .delete('/v2/1010/pushes/200')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.rejectPush(accountId, pushId).then(function(response) {
+      dnsimple.domains.rejectPush(accountId, pushId).then(function (response) {
         expect(response).to.eql({});
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });

--- a/test/dnsimple/domain_pushes.spec.js
+++ b/test/dnsimple/domain_pushes.spec.js
@@ -35,11 +35,11 @@ describe('domains', function () {
         var push = response.data;
         expect(push.id).to.eq(1);
         expect(push.domain_id).to.eq(100);
-        expect(push.contact_id).to.be.null;
+        expect(push.contact_id).to.eq(null);
         expect(push.account_id).to.eq(2020);
         expect(push.created_at).to.eq('2016-08-11T10:16:03Z');
         expect(push.updated_at).to.eq('2016-08-11T10:16:03Z');
-        expect(push.accepted_at).to.be.null;
+        expect(push.accepted_at).to.eq(null);
         done();
       }, function (error) {
         done(error);

--- a/test/dnsimple/domain_services.spec.js
+++ b/test/dnsimple/domain_services.spec.js
@@ -2,72 +2,72 @@
 
 var testUtils = require('../testUtils');
 var dnsimple = require('../../lib/dnsimple')({
-  accessToken: testUtils.getAccessToken(),
+  accessToken: testUtils.getAccessToken()
 });
 
 const expect = require('chai').expect;
 const nock = require('nock');
 
-describe('domain services', function() {
-  describe('#appliedServices', function() {
+describe('domain services', function () {
+  describe('#appliedServices', function () {
     var accountId = '1010';
-    var domainId = 'example.com'
+    var domainId = 'example.com';
     var fixture = testUtils.fixture('appliedServices/success.http');
 
-    it('supports pagination', function(done) {
+    it('supports pagination', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/services?page=1')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.services.appliedServices(accountId, domainId, {page: 1});
+      dnsimple.services.appliedServices(accountId, domainId, { page: 1 });
 
       nock.isDone();
       done();
     });
 
-    it('supports extra request options', function(done) {
+    it('supports extra request options', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/services?foo=bar')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.services.appliedServices(accountId, domainId, {query: {foo: 'bar'}});
+      dnsimple.services.appliedServices(accountId, domainId, { query: { foo: 'bar' } });
 
       nock.isDone();
       done();
     });
 
-    it('supports sorting', function(done) {
+    it('supports sorting', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/services?sort=name%3Aasc')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.services.appliedServices(accountId, domainId, {sort: 'name:asc'});
+      dnsimple.services.appliedServices(accountId, domainId, { sort: 'name:asc' });
 
       nock.isDone();
       done();
     });
 
-    it('produces a service list', function(done) {
+    it('produces a service list', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/services')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.services.appliedServices(accountId, domainId).then(function(response) {
+      dnsimple.services.appliedServices(accountId, domainId).then(function (response) {
         var services = response.data;
         expect(services.length).to.eq(1);
         expect(services[0].name).to.eq('WordPress');
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#allAppliedServices', function() {
+  describe('#allAppliedServices', function () {
     var accountId = '1010';
-    var domainId = 'example.com'
+    var domainId = 'example.com';
 
-    it('produces a complete list', function(done) {
+    it('produces a complete list', function (done) {
       var fixture1 = testUtils.fixture('pages-1of3.http');
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example.com/services?page=1')
@@ -83,56 +83,56 @@ describe('domain services', function() {
         .get('/v2/1010/domains/example.com/services?page=3')
         .reply(fixture3.statusCode, fixture3.body);
 
-      dnsimple.services.allAppliedServices(accountId, domainId).then(function(items) {
+      dnsimple.services.allAppliedServices(accountId, domainId).then(function (items) {
         expect(items.length).to.eq(5);
         expect(items[0].id).to.eq(1);
         expect(items[4].id).to.eq(5);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
-      }).catch(function(error) {
+      }).catch(function (error) {
         done(error);
       });
     });
   });
 
-  describe('#applyService', function() {
+  describe('#applyService', function () {
     var accountId = '1010';
     var domainId = 'example.com';
     var serviceId = 'name';
 
-    it('produces nothing', function(done) {
+    it('produces nothing', function (done) {
       var fixture = testUtils.fixture('applyService/success.http');
 
       nock('https://api.dnsimple.com')
         .post('/v2/1010/domains/example.com/services/name')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.services.applyService(accountId, domainId, serviceId).then(function(response) {
+      dnsimple.services.applyService(accountId, domainId, serviceId).then(function (response) {
         expect(response).to.eql({});
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#unapplyService', function() {
+  describe('#unapplyService', function () {
     var accountId = '1010';
     var domainId = 'example.com';
     var serviceId = 'name';
 
-    it('produces nothing', function(done) {
+    it('produces nothing', function (done) {
       var fixture = testUtils.fixture('unapplyService/success.http');
 
       nock('https://api.dnsimple.com')
         .delete('/v2/1010/domains/example.com/services/name')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.services.unapplyService(accountId, domainId, serviceId).then(function(response) {
+      dnsimple.services.unapplyService(accountId, domainId, serviceId).then(function (response) {
         expect(response).to.eql({});
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });

--- a/test/dnsimple/domains.spec.js
+++ b/test/dnsimple/domains.spec.js
@@ -80,7 +80,7 @@ describe('domains', function () {
 
       dnsimple.domains.listDomains(accountId).then(function (response) {
         var pagination = response.pagination;
-        expect(pagination).to.not.be.null;
+        expect(pagination).to.not.eq(null);
         expect(pagination.current_page).to.eq(1);
         done();
       }, function (error) {
@@ -135,12 +135,12 @@ describe('domains', function () {
         var domain = response.data;
         expect(domain.id).to.eq(1);
         expect(domain.account_id).to.eq(1010);
-        expect(domain.registrant_id).to.be.null;
+        expect(domain.registrant_id).to.eq(null);
         expect(domain.name).to.eq('example-alpha.com');
         expect(domain.state).to.eq('hosted');
         expect(domain.auto_renew).to.eq(false);
         expect(domain.private_whois).to.eq(false);
-        expect(domain.expires_on).to.be.null;
+        expect(domain.expires_on).to.eq(null);
         expect(domain.created_at).to.eq('2014-12-06T15:56:55Z');
         expect(domain.updated_at).to.eq('2015-12-09T00:20:56Z');
         done();
@@ -159,7 +159,7 @@ describe('domains', function () {
         dnsimple.domains.getDomain(accountId, 0).then(function (response) {
           done();
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           expect(error.description).to.eq('Not found');
           expect(error.message).to.eq('Domain `0` not found');
           done();

--- a/test/dnsimple/domains.spec.js
+++ b/test/dnsimple/domains.spec.js
@@ -2,97 +2,97 @@
 
 var testUtils = require('../testUtils');
 var dnsimple = require('../../lib/dnsimple')({
-  accessToken: testUtils.getAccessToken(),
+  accessToken: testUtils.getAccessToken()
 });
 
 const expect = require('chai').expect;
 const nock = require('nock');
 
-describe('domains', function() {
-  describe('#listDomains', function() {
+describe('domains', function () {
+  describe('#listDomains', function () {
     var accountId = '1010';
     var fixture = testUtils.fixture('listDomains/success.http');
 
-    it('supports pagination', function(done) {
+    it('supports pagination', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains?page=1')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.listDomains(accountId, {page: 1});
+      dnsimple.domains.listDomains(accountId, { page: 1 });
 
       nock.isDone();
       done();
     });
 
-    it('supports extra request options', function(done) {
+    it('supports extra request options', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains?foo=bar')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.listDomains(accountId, {query: {foo: 'bar'}});
+      dnsimple.domains.listDomains(accountId, { query: { foo: 'bar' } });
 
       nock.isDone();
       done();
     });
 
-    it('supports sorting', function(done) {
+    it('supports sorting', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains?sort=expires_on%3Aasc')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.listDomains(accountId, {sort: 'expires_on:asc'});
+      dnsimple.domains.listDomains(accountId, { sort: 'expires_on:asc' });
 
       nock.isDone();
       done();
     });
 
-    it('supports filter', function(done) {
+    it('supports filter', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains?name_like=example')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.listDomains(accountId, {filter: {name_like: 'example'}});
+      dnsimple.domains.listDomains(accountId, { filter: { name_like: 'example' } });
 
       nock.isDone();
       done();
     });
 
-    it('produces a domain list', function(done) {
+    it('produces a domain list', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.listDomains(accountId).then(function(response) {
+      dnsimple.domains.listDomains(accountId).then(function (response) {
         var domains = response.data;
         expect(domains.length).to.eq(2);
         expect(domains[0].name).to.eq('example-alpha.com');
         expect(domains[0].account_id).to.eq(1010);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    it('exposes the pagination info', function(done) {
+    it('exposes the pagination info', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.listDomains(accountId).then(function(response) {
+      dnsimple.domains.listDomains(accountId).then(function (response) {
         var pagination = response.pagination;
         expect(pagination).to.not.be.null;
         expect(pagination.current_page).to.eq(1);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#allDomains', function() {
+  describe('#allDomains', function () {
     var accountId = '1010';
 
-    it('produces a complete list', function(done) {
+    it('produces a complete list', function (done) {
       var fixture1 = testUtils.fixture('pages-1of3.http');
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains?page=1')
@@ -108,30 +108,30 @@ describe('domains', function() {
         .get('/v2/1010/domains?page=3')
         .reply(fixture3.statusCode, fixture3.body);
 
-      dnsimple.domains.allDomains(accountId).then(function(items) {
+      dnsimple.domains.allDomains(accountId).then(function (items) {
         expect(items.length).to.eq(5);
         expect(items[0].id).to.eq(1);
         expect(items[4].id).to.eq(5);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
-      }).catch(function(error) {
+      }).catch(function (error) {
         done(error);
       });
     });
   });
 
-  describe('#getDomain', function() {
+  describe('#getDomain', function () {
     var accountId = '1010';
     var domainId = 'example-alpha.com';
     var fixture = testUtils.fixture('getDomain/success.http');
 
-    it('produces a domain', function(done) {
+    it('produces a domain', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/example-alpha.com')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.getDomain(accountId, domainId).then(function(response) {
+      dnsimple.domains.getDomain(accountId, domainId).then(function (response) {
         var domain = response.data;
         expect(domain.id).to.eq(1);
         expect(domain.account_id).to.eq(1010);
@@ -144,21 +144,21 @@ describe('domains', function() {
         expect(domain.created_at).to.eq('2014-12-06T15:56:55Z');
         expect(domain.updated_at).to.eq('2015-12-09T00:20:56Z');
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    describe('when the domain does not exist', function() {
+    describe('when the domain does not exist', function () {
       var fixture = testUtils.fixture('notfound-domain.http');
       nock('https://api.dnsimple.com')
         .get('/v2/1010/domains/0')
         .reply(fixture.statusCode, fixture.body);
 
-      it('produces an error', function(done) {
-        dnsimple.domains.getDomain(accountId, 0).then(function(response) {
+      it('produces an error', function (done) {
+        dnsimple.domains.getDomain(accountId, 0).then(function (response) {
           done();
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           expect(error.description).to.eq('Not found');
           expect(error.message).to.eq('Domain `0` not found');
@@ -168,12 +168,12 @@ describe('domains', function() {
     });
   });
 
-  describe('#createDomain', function() {
+  describe('#createDomain', function () {
     var accountId = '1010';
-    var attributes = {name: 'example-alpha.com'};
+    var attributes = { name: 'example-alpha.com' };
     var fixture = testUtils.fixture('createDomain/created.http');
 
-    it('builds the correct request', function(done) {
+    it('builds the correct request', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/1010/domains', attributes)
         .reply(fixture.statusCode, fixture.body);
@@ -184,59 +184,57 @@ describe('domains', function() {
       done();
     });
 
-    it('produces a domain', function(done) {
+    it('produces a domain', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/1010/domains')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.createDomain(accountId, attributes).then(function(response) {
+      dnsimple.domains.createDomain(accountId, attributes).then(function (response) {
         var domain = response.data;
         expect(domain.id).to.eq(1);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#deleteDomain', function() {
+  describe('#deleteDomain', function () {
     var accountId = '1010';
     var domainId = 'example.com';
     var fixture = testUtils.fixture('deleteDomain/success.http');
 
-    it('produces nothing', function(done) {
+    it('produces nothing', function (done) {
       nock('https://api.dnsimple.com')
         .delete('/v2/1010/domains/example.com')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.deleteDomain(accountId, domainId).then(function(response) {
+      dnsimple.domains.deleteDomain(accountId, domainId).then(function (response) {
         expect(response).to.eql({});
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#resetDomainToken', function() {
+  describe('#resetDomainToken', function () {
     var accountId = '1010';
     var domainId = 'example.com';
     var fixture = testUtils.fixture('resetDomainToken/success.http');
 
-    it('produces a domain', function(done) {
+    it('produces a domain', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/1010/domains/example.com/token')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.resetDomainToken(accountId, domainId).then(function(response) {
-        var domain = response.data
+      dnsimple.domains.resetDomainToken(accountId, domainId).then(function (response) {
+        var domain = response.data;
         expect(domain.id).to.eq(1);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
-
   });
-
 });

--- a/test/dnsimple/identity.spec.js
+++ b/test/dnsimple/identity.spec.js
@@ -16,7 +16,7 @@ describe('identity', function () {
 
     it('produces an account', function (done) {
       dnsimple.identity.whoami().then(function (response) {
-        expect(response.data.user).to.be.null;
+        expect(response.data.user).to.eq(null);
         var account = response.data.account;
         expect(account.id).to.eql(1);
         expect(account.email).to.eql('example-account@example.com');
@@ -35,7 +35,7 @@ describe('identity', function () {
 
     it('produces a user', function (done) {
       dnsimple.identity.whoami().then(function (response) {
-        expect(response.data.account).to.be.null;
+        expect(response.data.account).to.eq(null);
         var user = response.data.user;
         expect(user.id).to.eql(1);
         expect(user.email).to.eql('example-user@example.com');

--- a/test/dnsimple/identity.spec.js
+++ b/test/dnsimple/identity.spec.js
@@ -2,45 +2,45 @@
 
 var testUtils = require('../testUtils');
 var dnsimple = require('../../lib/dnsimple')({
-  accessToken: testUtils.getAccessToken(),
+  accessToken: testUtils.getAccessToken()
 });
 var expect = require('chai').expect;
 var nock = require('nock');
 
-describe('identity', function() {
-  describe('#whoami when authenticated as account', function() {
+describe('identity', function () {
+  describe('#whoami when authenticated as account', function () {
     var fixture = testUtils.fixture('whoami/success-account.http');
     nock('https://api.dnsimple.com')
-                     .get('/v2/whoami')
-                     .reply(fixture.statusCode, fixture.body);
+      .get('/v2/whoami')
+      .reply(fixture.statusCode, fixture.body);
 
-    it('produces an account', function(done) {
-      dnsimple.identity.whoami().then(function(response) {
+    it('produces an account', function (done) {
+      dnsimple.identity.whoami().then(function (response) {
         expect(response.data.user).to.be.null;
         var account = response.data.account;
         expect(account.id).to.eql(1);
         expect(account.email).to.eql('example-account@example.com');
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#whoami when authenticated as user', function() {
+  describe('#whoami when authenticated as user', function () {
     var fixture = testUtils.fixture('whoami/success-user.http');
     nock('https://api.dnsimple.com')
-                     .get('/v2/whoami')
-                     .reply(fixture.statusCode, fixture.body);
+      .get('/v2/whoami')
+      .reply(fixture.statusCode, fixture.body);
 
-    it('produces a user', function(done) {
-      dnsimple.identity.whoami().then(function(response) {
+    it('produces a user', function (done) {
+      dnsimple.identity.whoami().then(function (response) {
         expect(response.data.account).to.be.null;
         var user = response.data.user;
         expect(user.id).to.eql(1);
         expect(user.email).to.eql('example-user@example.com');
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });

--- a/test/dnsimple/oauth.spec.js
+++ b/test/dnsimple/oauth.spec.js
@@ -8,7 +8,6 @@ var dnsimple = require('../../lib/dnsimple')({
 const expect = require('chai').expect;
 const nock = require('nock');
 
-const url = require('url');
 const querystring = require('querystring');
 
 describe('oauth', function () {
@@ -82,8 +81,8 @@ describe('oauth', function () {
 
   describe('#authorizeUrl', function () {
     it('builds the correct url', function () {
-      const authorizeUrl = url.parse(dnsimple.oauth.authorizeUrl('great-app'));
-      const expectedUrl = url.parse('https://dnsimple.com/oauth/authorize?client_id=great-app&response_type=code');
+      const authorizeUrl = new URL(dnsimple.oauth.authorizeUrl('great-app'));
+      const expectedUrl = new URL('https://dnsimple.com/oauth/authorize?client_id=great-app&response_type=code');
 
       expect(authorizeUrl.protocol).to.eq(expectedUrl.protocol);
       expect(authorizeUrl.host).to.eq(expectedUrl.host);
@@ -92,11 +91,11 @@ describe('oauth', function () {
 
     it('exposes the options in the query string', function () {
       var authorizeUrl = dnsimple.oauth.authorizeUrl('great-app', { secret: '1', redirect_uri: 'http://example.com' });
-      authorizeUrl = url.parse(authorizeUrl);
+      authorizeUrl = new URL(authorizeUrl);
 
       var expectedUrl = 'https://dnsimple.com/oauth/authorize';
       expectedUrl += '?client_id=great-app&secret=1&redirect_uri=http://example.com&response_type=code';
-      expectedUrl = url.parse(expectedUrl);
+      expectedUrl = new URL(expectedUrl);
 
       expect(authorizeUrl.protocol).to.eq(expectedUrl.protocol);
       expect(authorizeUrl.host).to.eq(expectedUrl.host);

--- a/test/dnsimple/oauth.spec.js
+++ b/test/dnsimple/oauth.spec.js
@@ -2,7 +2,7 @@
 
 var testUtils = require('../testUtils');
 var dnsimple = require('../../lib/dnsimple')({
-  accessToken: testUtils.getAccessToken(),
+  accessToken: testUtils.getAccessToken()
 });
 
 const expect = require('chai').expect;
@@ -11,21 +11,21 @@ const nock = require('nock');
 const url = require('url');
 const querystring = require('querystring');
 
-describe('oauth', function() {
+describe('oauth', function () {
   var clientId = 'super-client';
   var clientSecret = 'super-secret';
   var code = 'super-code';
 
-  describe('#exchangeAuthorizationForToken', function() {
+  describe('#exchangeAuthorizationForToken', function () {
     var fixture = testUtils.fixture('oauthAccessToken/success.http');
 
-    it('builds the correct request', function(done) {
+    it('builds the correct request', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/oauth/access_token', {
           client_id: clientId,
           client_secret: clientSecret,
           code: code,
-          grant_type: 'authorization_code',
+          grant_type: 'authorization_code'
         })
         .reply(fixture.statusCode, fixture.body);
 
@@ -35,31 +35,31 @@ describe('oauth', function() {
       done();
     });
 
-    it('returns the oauth token', function(done) {
+    it('returns the oauth token', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/oauth/access_token', {
           client_id: clientId,
           client_secret: clientSecret,
           code: code,
-          grant_type: 'authorization_code',
+          grant_type: 'authorization_code'
         })
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.oauth.exchangeAuthorizationForToken(code, clientId, clientSecret).then(function(response) {
+      dnsimple.oauth.exchangeAuthorizationForToken(code, clientId, clientSecret).then(function (response) {
         expect(response.access_token).to.eq('zKQ7OLqF5N1gylcJweA9WodA000BUNJD');
         expect(response.token_type).to.eq('Bearer');
         expect(response.account_id).to.eq(1);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    describe('when state and redirect_uri are provided', function() {
+    describe('when state and redirect_uri are provided', function () {
       var state = 'super-state';
       var redirectUri = 'super-redirect-uri';
 
-      it('builds the correct request', function(done) {
+      it('builds the correct request', function (done) {
         nock('https://api.dnsimple.com')
           .post('/v2/oauth/access_token', {
             client_id: clientId,
@@ -67,11 +67,11 @@ describe('oauth', function() {
             code: code,
             grant_type: 'authorization_code',
             state: state,
-            redirect_uri: redirectUri,
+            redirect_uri: redirectUri
           })
           .reply(fixture.statusCode, fixture.body);
 
-        let options = {state: state, redirectUri: redirectUri};
+        const options = { state: state, redirectUri: redirectUri };
         dnsimple.oauth.exchangeAuthorizationForToken(code, clientId, clientSecret, options);
 
         nock.isDone();
@@ -80,22 +80,22 @@ describe('oauth', function() {
     });
   });
 
-  describe('#authorizeUrl', function() {
-    it('builds the correct url', function() {
-      let authorizeUrl = url.parse(dnsimple.oauth.authorizeUrl('great-app'));
-      let expectedUrl = url.parse('https://dnsimple.com/oauth/authorize?client_id=great-app&response_type=code');
+  describe('#authorizeUrl', function () {
+    it('builds the correct url', function () {
+      const authorizeUrl = url.parse(dnsimple.oauth.authorizeUrl('great-app'));
+      const expectedUrl = url.parse('https://dnsimple.com/oauth/authorize?client_id=great-app&response_type=code');
 
       expect(authorizeUrl.protocol).to.eq(expectedUrl.protocol);
       expect(authorizeUrl.host).to.eq(expectedUrl.host);
       expect(querystring.parse(authorizeUrl.query)).to.deep.equal(querystring.parse(expectedUrl.query));
     });
 
-    it('exposes the options in the query string', function() {
-      var authorizeUrl = dnsimple.oauth.authorizeUrl('great-app', {secret: '1', redirect_uri: 'http://example.com'});
+    it('exposes the options in the query string', function () {
+      var authorizeUrl = dnsimple.oauth.authorizeUrl('great-app', { secret: '1', redirect_uri: 'http://example.com' });
       authorizeUrl = url.parse(authorizeUrl);
 
       var expectedUrl = 'https://dnsimple.com/oauth/authorize';
-      expectedUrl += '?client_id=great-app&secret=1&redirect_uri=http://example.com&response_type=code'
+      expectedUrl += '?client_id=great-app&secret=1&redirect_uri=http://example.com&response_type=code';
       expectedUrl = url.parse(expectedUrl);
 
       expect(authorizeUrl.protocol).to.eq(expectedUrl.protocol);
@@ -103,5 +103,4 @@ describe('oauth', function() {
       expect(querystring.parse(authorizeUrl.query)).to.deep.equal(querystring.parse(expectedUrl.query));
     });
   });
-
 });

--- a/test/dnsimple/registrar.spec.js
+++ b/test/dnsimple/registrar.spec.js
@@ -24,8 +24,8 @@ describe('registrar', function () {
       dnsimple.registrar.checkDomain(accountId, domainId).then(function (response) {
         var checkResult = response.data;
         expect(checkResult.domain).to.eql('ruby.codes');
-        expect(checkResult.available).to.be.true;
-        expect(checkResult.premium).to.be.true;
+        expect(checkResult.available).to.eq(true);
+        expect(checkResult.premium).to.eq(true);
         done();
       }, function (error) {
         done(error);
@@ -66,7 +66,7 @@ describe('registrar', function () {
         dnsimple.registrar.getDomainPremiumPrice(accountId, domainId).then(function (response) {
           done();
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           expect(error.description).to.eq('Bad request');
           expect(error.message).to.eq('`example.com` is not a premium domain for registration');
           done();
@@ -129,7 +129,7 @@ describe('registrar', function () {
         dnsimple.registrar.renewDomain(accountId, domainId, attributes).then(function (response) {
           done('Expected error, but future resolved');
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           done();
         });
       });
@@ -166,7 +166,7 @@ describe('registrar', function () {
         dnsimple.registrar.transferDomain(accountId, domainId, attributes).then(function (response) {
           done('Expected error, but future resolved');
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           done();
         });
       });
@@ -185,7 +185,7 @@ describe('registrar', function () {
         dnsimple.registrar.transferDomain(accountId, domainId, attributes).then(function (response) {
           done('Expected error, but future resolved');
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           done();
         });
       });

--- a/test/dnsimple/registrar.spec.js
+++ b/test/dnsimple/registrar.spec.js
@@ -2,70 +2,70 @@
 
 var testUtils = require('../testUtils');
 var dnsimple = require('../../lib/dnsimple')({
-  accessToken: testUtils.getAccessToken(),
+  accessToken: testUtils.getAccessToken()
 });
 
 const expect = require('chai').expect;
 const nock = require('nock');
 
-describe('registrar', function() {
-  let accountId = '1010';
-  let domainId = 'example.com';
+describe('registrar', function () {
+  const accountId = '1010';
+  const domainId = 'example.com';
 
-  describe('#checkDomain', function() {
-    let domainId = 'ruby.codes';
+  describe('#checkDomain', function () {
+    const domainId = 'ruby.codes';
     var fixture = testUtils.fixture('checkDomain/success.http');
 
-    it('produces a check result', function(done) {
+    it('produces a check result', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/registrar/domains/ruby.codes/check')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.registrar.checkDomain(accountId, domainId).then(function(response) {
+      dnsimple.registrar.checkDomain(accountId, domainId).then(function (response) {
         var checkResult = response.data;
         expect(checkResult.domain).to.eql('ruby.codes');
         expect(checkResult.available).to.be.true;
         expect(checkResult.premium).to.be.true;
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#getDomainPremiumPrice', function() {
-    describe('when the domain has a premium price', function() {
-      let domainId = 'ruby.codes';
+  describe('#getDomainPremiumPrice', function () {
+    describe('when the domain has a premium price', function () {
+      const domainId = 'ruby.codes';
       var fixture = testUtils.fixture('getDomainPremiumPrice/success.http');
 
-      it('produces a premium price result', function(done) {
+      it('produces a premium price result', function (done) {
         nock('https://api.dnsimple.com')
           .get('/v2/1010/registrar/domains/ruby.codes/premium_price')
           .reply(fixture.statusCode, fixture.body);
 
-        dnsimple.registrar.getDomainPremiumPrice(accountId, domainId).then(function(response) {
+        dnsimple.registrar.getDomainPremiumPrice(accountId, domainId).then(function (response) {
           var premiumPriceResult = response.data;
           expect(premiumPriceResult.premium_price).to.eql('109.00');
           expect(premiumPriceResult.action).to.eql('registration');
           done();
-        }, function(error) {
+        }, function (error) {
           done(error);
         });
       });
     });
 
-    describe('when the domain is not a premium domain', function() {
-      let domainId = 'example.com';
+    describe('when the domain is not a premium domain', function () {
+      const domainId = 'example.com';
       var fixture = testUtils.fixture('getDomainPremiumPrice/failure.http');
 
-      it('produces an error', function(done) {
+      it('produces an error', function (done) {
         nock('https://api.dnsimple.com')
           .get('/v2/1010/registrar/domains/example.com/premium_price')
           .reply(fixture.statusCode, fixture.body);
 
-        dnsimple.registrar.getDomainPremiumPrice(accountId, domainId).then(function(response) {
+        dnsimple.registrar.getDomainPremiumPrice(accountId, domainId).then(function (response) {
           done();
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           expect(error.description).to.eq('Bad request');
           expect(error.message).to.eq('`example.com` is not a premium domain for registration');
@@ -75,60 +75,60 @@ describe('registrar', function() {
     });
   });
 
-  describe('#registerDomain', function() {
+  describe('#registerDomain', function () {
     var fixture = testUtils.fixture('registerDomain/success.http');
 
-    it('produces a domain', function(done) {
-      var attributes = {registrant_id: '10'};
+    it('produces a domain', function (done) {
+      var attributes = { registrant_id: '10' };
 
       nock('https://api.dnsimple.com')
         .post('/v2/1010/registrar/domains/example.com/registrations', attributes)
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.registrar.registerDomain(accountId, domainId, attributes).then(function(response) {
+      dnsimple.registrar.registerDomain(accountId, domainId, attributes).then(function (response) {
         var domainRegistration = response.data;
         expect(domainRegistration.id).to.eq(1);
         expect(domainRegistration.state).to.eq('new');
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#renewDomain', function() {
+  describe('#renewDomain', function () {
     var fixture = testUtils.fixture('renewDomain/success.http');
 
-    it('produces a domain', function(done) {
-      var attributes = {period: '3'};
+    it('produces a domain', function (done) {
+      var attributes = { period: '3' };
 
       nock('https://api.dnsimple.com')
         .post('/v2/1010/registrar/domains/example.com/renewals', attributes)
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.registrar.renewDomain(accountId, domainId, attributes).then(function(response) {
+      dnsimple.registrar.renewDomain(accountId, domainId, attributes).then(function (response) {
         var domainRenewal = response.data;
         expect(domainRenewal.id).to.eq(1);
         expect(domainRenewal.state).to.eq('new');
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    describe('when it is too soon for the domain to be renewed', function() {
+    describe('when it is too soon for the domain to be renewed', function () {
       var fixture = testUtils.fixture('renewDomain/error-tooearly.http');
 
-      it('results in an error', function(done) {
+      it('results in an error', function (done) {
         var attributes = {};
 
         nock('https://api.dnsimple.com')
           .post('/v2/1010/registrar/domains/example.com/renewals', attributes)
           .reply(fixture.statusCode, fixture.body);
 
-        dnsimple.registrar.renewDomain(accountId, domainId, attributes).then(function(response) {
+        dnsimple.registrar.renewDomain(accountId, domainId, attributes).then(function (response) {
           done('Expected error, but future resolved');
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           done();
         });
@@ -136,55 +136,55 @@ describe('registrar', function() {
     });
   });
 
-  describe('#transferDomain', function() {
-    var attributes = {registrant_id: '10', auth_code: 'x1y2z3'};
+  describe('#transferDomain', function () {
+    var attributes = { registrant_id: '10', auth_code: 'x1y2z3' };
 
-    it('produces a domain', function(done) {
+    it('produces a domain', function (done) {
       var fixture = testUtils.fixture('transferDomain/success.http');
       nock('https://api.dnsimple.com')
         .post('/v2/1010/registrar/domains/example.com/transfers', attributes)
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.registrar.transferDomain(accountId, domainId, attributes).then(function(response) {
+      dnsimple.registrar.transferDomain(accountId, domainId, attributes).then(function (response) {
         var domain = response.data;
         expect(domain.id).to.eq(1);
         expect(domain.state).to.eq('transferring');
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    describe('when the domain is already in DNSimple', function() {
+    describe('when the domain is already in DNSimple', function () {
       var fixture = testUtils.fixture('transferDomain/error-indnsimple.http');
 
-      it('results in an error', function(done) {
+      it('results in an error', function (done) {
         nock('https://api.dnsimple.com')
           .post('/v2/1010/registrar/domains/example.com/transfers', attributes)
           .reply(fixture.statusCode, fixture.body);
 
-        dnsimple.registrar.transferDomain(accountId, domainId, attributes).then(function(response) {
+        dnsimple.registrar.transferDomain(accountId, domainId, attributes).then(function (response) {
           done('Expected error, but future resolved');
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           done();
         });
       });
     });
 
-    describe('when authcode was not provided and is required by the TLD', function() {
+    describe('when authcode was not provided and is required by the TLD', function () {
       var fixture = testUtils.fixture('transferDomain/error-missing-authcode.http');
 
-      it('results in an error', function(done) {
-        var attributes = {registrant_id: '10'};
+      it('results in an error', function (done) {
+        var attributes = { registrant_id: '10' };
 
         nock('https://api.dnsimple.com')
           .post('/v2/1010/registrar/domains/example.com/transfers', attributes)
           .reply(fixture.statusCode, fixture.body);
 
-        dnsimple.registrar.transferDomain(accountId, domainId, attributes).then(function(response) {
+        dnsimple.registrar.transferDomain(accountId, domainId, attributes).then(function (response) {
           done('Expected error, but future resolved');
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           done();
         });
@@ -192,18 +192,18 @@ describe('registrar', function() {
     });
   });
 
-  describe('#transferDomainOut', function() {
+  describe('#transferDomainOut', function () {
     var fixture = testUtils.fixture('authorizeDomainTransferOut/success.http');
 
-    it('produces nothing', function(done) {
+    it('produces nothing', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/1010/registrar/domains/example.com/authorize_transfer_out')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.registrar.transferDomainOut(accountId, domainId).then(function(response) {
+      dnsimple.registrar.transferDomainOut(accountId, domainId).then(function (response) {
         expect(response).to.eql({});
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });

--- a/test/dnsimple/registrar_auto_renewal.spec.js
+++ b/test/dnsimple/registrar_auto_renewal.spec.js
@@ -39,7 +39,7 @@ describe('registrar auto renewal', function () {
         dnsimple.registrar.enableDomainAutoRenewal(accountId, domainId).then(function (response) {
           done('Expected error but future resolved');
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           done();
         });
       });
@@ -73,7 +73,7 @@ describe('registrar auto renewal', function () {
         dnsimple.registrar.disableDomainAutoRenewal(accountId, domainId).then(function (response) {
           done('Expected error but future resolved');
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           done();
         });
       });

--- a/test/dnsimple/registrar_auto_renewal.spec.js
+++ b/test/dnsimple/registrar_auto_renewal.spec.js
@@ -2,43 +2,43 @@
 
 var testUtils = require('../testUtils');
 var dnsimple = require('../../lib/dnsimple')({
-  accessToken: testUtils.getAccessToken(),
+  accessToken: testUtils.getAccessToken()
 });
 
 const expect = require('chai').expect;
 const nock = require('nock');
 
-describe('registrar auto renewal', function() {
-  let accountId = '1010';
-  let domainId = 'example.com';
+describe('registrar auto renewal', function () {
+  const accountId = '1010';
+  const domainId = 'example.com';
 
-  describe('#enableDomainAutoRenewal', function() {
+  describe('#enableDomainAutoRenewal', function () {
     var fixture = testUtils.fixture('enableDomainAutoRenewal/success.http');
 
-    it('produces an empty result', function(done) {
+    it('produces an empty result', function (done) {
       nock('https://api.dnsimple.com')
         .put('/v2/1010/registrar/domains/example.com/auto_renewal')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.registrar.enableDomainAutoRenewal(accountId, domainId).then(function(response) {
+      dnsimple.registrar.enableDomainAutoRenewal(accountId, domainId).then(function (response) {
         expect(response).to.eql({});
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    describe('when the domain does not exist', function() {
-      it('results in an error', function(done) {
+    describe('when the domain does not exist', function () {
+      it('results in an error', function (done) {
         var fixture = testUtils.fixture('notfound-domain.http');
 
         nock('https://api.dnsimple.com')
           .put('/v2/1010/registrar/domains/example.com/auto_renewal')
           .reply(fixture.statusCode, fixture.body);
 
-        dnsimple.registrar.enableDomainAutoRenewal(accountId, domainId).then(function(response) {
+        dnsimple.registrar.enableDomainAutoRenewal(accountId, domainId).then(function (response) {
           done('Expected error but future resolved');
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           done();
         });
@@ -46,33 +46,33 @@ describe('registrar auto renewal', function() {
     });
   });
 
-  describe('#disableDomainAutoRenewal', function() {
+  describe('#disableDomainAutoRenewal', function () {
     var fixture = testUtils.fixture('disableDomainAutoRenewal/success.http');
 
-    it('produces an empty result', function(done) {
+    it('produces an empty result', function (done) {
       nock('https://api.dnsimple.com')
         .delete('/v2/1010/registrar/domains/example.com/auto_renewal')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.registrar.disableDomainAutoRenewal(accountId, domainId).then(function(response) {
+      dnsimple.registrar.disableDomainAutoRenewal(accountId, domainId).then(function (response) {
         expect(response).to.eql({});
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    describe('when the domain does not exist', function() {
-      it('results in an error', function(done) {
+    describe('when the domain does not exist', function () {
+      it('results in an error', function (done) {
         var fixture = testUtils.fixture('notfound-domain.http');
 
         nock('https://api.dnsimple.com')
           .delete('/v2/1010/registrar/domains/example.com/auto_renewal')
           .reply(fixture.statusCode, fixture.body);
 
-        dnsimple.registrar.disableDomainAutoRenewal(accountId, domainId).then(function(response) {
+        dnsimple.registrar.disableDomainAutoRenewal(accountId, domainId).then(function (response) {
           done('Expected error but future resolved');
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           done();
         });

--- a/test/dnsimple/registrar_domain_delegation.spec.js
+++ b/test/dnsimple/registrar_domain_delegation.spec.js
@@ -2,93 +2,93 @@
 
 var testUtils = require('../testUtils');
 var dnsimple = require('../../lib/dnsimple')({
-  accessToken: testUtils.getAccessToken(),
+  accessToken: testUtils.getAccessToken()
 });
 
 const expect = require('chai').expect;
 const nock = require('nock');
 
-describe('domain delegation', function() {
-  let accountId = '1010';
-  let domainId = 'example.com';
+describe('domain delegation', function () {
+  const accountId = '1010';
+  const domainId = 'example.com';
 
-  describe('#getDomainDelegation', function() {
+  describe('#getDomainDelegation', function () {
     var fixture = testUtils.fixture('getDomainDelegation/success.http');
 
-    it('produces a name server list', function(done) {
+    it('produces a name server list', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/registrar/domains/example.com/delegation')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.registrar.getDomainDelegation(accountId, domainId).then(function(response) {
-        var delegation = response.data
+      dnsimple.registrar.getDomainDelegation(accountId, domainId).then(function (response) {
+        var delegation = response.data;
         expect(delegation).to.eql([
           'ns1.dnsimple.com',
           'ns2.dnsimple.com',
           'ns3.dnsimple.com',
-          'ns4.dnsimple.com',
-          ]);
+          'ns4.dnsimple.com'
+        ]);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#changeDomainDelegation', function() {
-    var attributes = ['ns1.dnsimple.com','ns2.dnsimple.com','ns3.dnsimple.com','ns4.dnsimple.com'];
+  describe('#changeDomainDelegation', function () {
+    var attributes = ['ns1.dnsimple.com', 'ns2.dnsimple.com', 'ns3.dnsimple.com', 'ns4.dnsimple.com'];
 
-    it('produces a name server list', function(done) {
+    it('produces a name server list', function (done) {
       var fixture = testUtils.fixture('changeDomainDelegation/success.http');
       nock('https://api.dnsimple.com')
         .put('/v2/1010/registrar/domains/example.com/delegation', attributes)
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.registrar.changeDomainDelegation(accountId, domainId, attributes).then(function(response) {
-        var delegation = response.data
+      dnsimple.registrar.changeDomainDelegation(accountId, domainId, attributes).then(function (response) {
+        var delegation = response.data;
         expect(delegation).to.eql([
           'ns1.dnsimple.com',
           'ns2.dnsimple.com',
           'ns3.dnsimple.com',
-          'ns4.dnsimple.com',
-          ]);
+          'ns4.dnsimple.com'
+        ]);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#changeDomainDelegationToVanity', function() {
-    var attributes = ['ns1.example.com','ns2.example.com'];
+  describe('#changeDomainDelegationToVanity', function () {
+    var attributes = ['ns1.example.com', 'ns2.example.com'];
 
-    it('produces a name server list', function(done) {
+    it('produces a name server list', function (done) {
       var fixture = testUtils.fixture('changeDomainDelegationToVanity/success.http');
       nock('https://api.dnsimple.com')
         .put('/v2/1010/registrar/domains/example.com/delegation/vanity', attributes)
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.registrar.changeDomainDelegationToVanity(accountId, domainId, attributes).then(function(response) {
-        var delegation = response.data
+      dnsimple.registrar.changeDomainDelegationToVanity(accountId, domainId, attributes).then(function (response) {
+        var delegation = response.data;
         expect(delegation.length).to.eq(2);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#changeDomainDelegationFromVanity', function() {
-    it('produces nothing', function(done) {
+  describe('#changeDomainDelegationFromVanity', function () {
+    it('produces nothing', function (done) {
       var fixture = testUtils.fixture('changeDomainDelegationFromVanity/success.http');
       nock('https://api.dnsimple.com')
         .delete('/v2/1010/registrar/domains/example.com/delegation/vanity')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.registrar.changeDomainDelegationFromVanity(accountId, domainId).then(function(response) {
+      dnsimple.registrar.changeDomainDelegationFromVanity(accountId, domainId).then(function (response) {
         expect(response).to.eql({});
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });

--- a/test/dnsimple/registrar_whois_privacy.spec.js
+++ b/test/dnsimple/registrar_whois_privacy.spec.js
@@ -25,7 +25,7 @@ describe('whois privacy', function () {
         expect(whoisPrivacy.id).to.eq(1);
         expect(whoisPrivacy.domain_id).to.eq(2);
         expect(whoisPrivacy.expires_on).to.eq('2017-02-13');
-        expect(whoisPrivacy.enabled).to.be.true;
+        expect(whoisPrivacy.enabled).to.eq(true);
         expect(whoisPrivacy.created_at).to.eq('2016-02-13T14:34:50Z');
         expect(whoisPrivacy.updated_at).to.eq('2016-02-13T14:34:52Z');
         done();

--- a/test/dnsimple/registrar_whois_privacy.spec.js
+++ b/test/dnsimple/registrar_whois_privacy.spec.js
@@ -2,25 +2,25 @@
 
 var testUtils = require('../testUtils');
 var dnsimple = require('../../lib/dnsimple')({
-  accessToken: testUtils.getAccessToken(),
+  accessToken: testUtils.getAccessToken()
 });
 
 const expect = require('chai').expect;
 const nock = require('nock');
 
-describe('whois privacy', function() {
-  let accountId = '1010';
-  let domainId = 'example.com';
+describe('whois privacy', function () {
+  const accountId = '1010';
+  const domainId = 'example.com';
 
-  describe('#getWhoisPrivacy', function() {
+  describe('#getWhoisPrivacy', function () {
     var fixture = testUtils.fixture('getWhoisPrivacy/success.http');
 
-    it('produces a whois privacy', function(done) {
+    it('produces a whois privacy', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/registrar/domains/example.com/whois_privacy')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.registrar.getWhoisPrivacy(accountId, domainId).then(function(response) {
+      dnsimple.registrar.getWhoisPrivacy(accountId, domainId).then(function (response) {
         var whoisPrivacy = response.data;
         expect(whoisPrivacy.id).to.eq(1);
         expect(whoisPrivacy.domain_id).to.eq(2);
@@ -29,80 +29,80 @@ describe('whois privacy', function() {
         expect(whoisPrivacy.created_at).to.eq('2016-02-13T14:34:50Z');
         expect(whoisPrivacy.updated_at).to.eq('2016-02-13T14:34:52Z');
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#enableWhoisPrivacy', function() {
-    describe('when whois privacy is already purchased', function() {
+  describe('#enableWhoisPrivacy', function () {
+    describe('when whois privacy is already purchased', function () {
       var fixture = testUtils.fixture('enableWhoisPrivacy/success.http');
 
-      it('produces a whois privacy', function(done) {
+      it('produces a whois privacy', function (done) {
         nock('https://api.dnsimple.com')
           .put('/v2/1010/registrar/domains/example.com/whois_privacy')
           .reply(fixture.statusCode, fixture.body);
 
-        dnsimple.registrar.enableWhoisPrivacy(accountId, domainId).then(function(response) {
+        dnsimple.registrar.enableWhoisPrivacy(accountId, domainId).then(function (response) {
           var whoisPrivacy = response.data;
           expect(whoisPrivacy.id).to.eq(1);
           expect(whoisPrivacy.domain_id).to.eq(2);
           done();
-        }, function(error) {
+        }, function (error) {
           done(error);
         });
       });
     });
 
-    describe('when whois privacy is newly purchased', function() {
+    describe('when whois privacy is newly purchased', function () {
       var fixture = testUtils.fixture('enableWhoisPrivacy/created.http');
 
-      it('produces a whois privacy', function(done) {
+      it('produces a whois privacy', function (done) {
         nock('https://api.dnsimple.com')
           .put('/v2/1010/registrar/domains/example.com/whois_privacy')
           .reply(fixture.statusCode, fixture.body);
 
-        dnsimple.registrar.enableWhoisPrivacy(accountId, domainId).then(function(response) {
+        dnsimple.registrar.enableWhoisPrivacy(accountId, domainId).then(function (response) {
           var whoisPrivacy = response.data;
           expect(whoisPrivacy.id).to.eq(1);
           expect(whoisPrivacy.domain_id).to.eq(2);
           done();
-        }, function(error) {
+        }, function (error) {
           done(error);
         });
       });
     });
   });
 
-  describe('#disableWhoisPrivacy', function() {
+  describe('#disableWhoisPrivacy', function () {
     var fixture = testUtils.fixture('disableWhoisPrivacy/success.http');
 
-    it('produces a whois privacy', function(done) {
+    it('produces a whois privacy', function (done) {
       nock('https://api.dnsimple.com')
         .delete('/v2/1010/registrar/domains/example.com/whois_privacy')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.registrar.disableWhoisPrivacy(accountId, domainId).then(function(response) {
+      dnsimple.registrar.disableWhoisPrivacy(accountId, domainId).then(function (response) {
         var whoisPrivacy = response.data;
         expect(whoisPrivacy.id).to.eq(1);
         expect(whoisPrivacy.domain_id).to.eq(2);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#renewWhoisPrivacy', function() {
+  describe('#renewWhoisPrivacy', function () {
     var fixture = testUtils.fixture('renewWhoisPrivacy/success.http');
 
-    it('produces a whois privacy renewal', function(done) {
+    it('produces a whois privacy renewal', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/1010/registrar/domains/example.com/whois_privacy/renewals')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.registrar.renewWhoisPrivacy(accountId, domainId).then(function(response) {
+      dnsimple.registrar.renewWhoisPrivacy(accountId, domainId).then(function (response) {
         var whoisPrivacyRenewal = response.data;
         expect(whoisPrivacyRenewal.id).to.eq(1);
         expect(whoisPrivacyRenewal.domain_id).to.eq(100);
@@ -110,7 +110,7 @@ describe('whois privacy', function() {
         expect(whoisPrivacyRenewal.state).to.eq('new');
         expect(whoisPrivacyRenewal.enabled).to.eq(true);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });

--- a/test/dnsimple/services.spec.js
+++ b/test/dnsimple/services.spec.js
@@ -68,7 +68,7 @@ describe('services', function () {
 
       dnsimple.services.listServices().then(function (response) {
         var pagination = response.pagination;
-        expect(pagination).to.not.be.null;
+        expect(pagination).to.not.eq(null);
         expect(pagination.current_page).to.eq(1);
         done();
       }, function (error) {

--- a/test/dnsimple/services.spec.js
+++ b/test/dnsimple/services.spec.js
@@ -2,83 +2,83 @@
 
 var testUtils = require('../testUtils');
 var dnsimple = require('../../lib/dnsimple')({
-  accessToken: testUtils.getAccessToken(),
+  accessToken: testUtils.getAccessToken()
 });
 
 const expect = require('chai').expect;
 const nock = require('nock');
 
-describe('services', function() {
-  describe('#listServices', function() {
+describe('services', function () {
+  describe('#listServices', function () {
     var fixture = testUtils.fixture('listServices/success.http');
 
-    it('supports pagination', function(done) {
+    it('supports pagination', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/services?page=1')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.services.listServices({page: 1});
+      dnsimple.services.listServices({ page: 1 });
 
       nock.isDone();
       done();
     });
 
-    it('supports extra request options', function(done) {
+    it('supports extra request options', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/services?foo=bar')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.services.listServices({query: {foo: 'bar'}});
+      dnsimple.services.listServices({ query: { foo: 'bar' } });
 
       nock.isDone();
       done();
     });
 
-    it('supports sorting', function(done) {
+    it('supports sorting', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/services?sort=name%3Aasc')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.services.listServices({sort: 'name:asc'});
+      dnsimple.services.listServices({ sort: 'name:asc' });
 
       nock.isDone();
       done();
     });
 
-    it('produces a service list', function(done) {
+    it('produces a service list', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/services')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.services.listServices().then(function(response) {
+      dnsimple.services.listServices().then(function (response) {
         var services = response.data;
         expect(services.length).to.eq(2);
         expect(services[0].name).to.eq('Service 1');
         expect(services[0].sid).to.eq('service1');
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    it('exposes the pagination info', function(done) {
+    it('exposes the pagination info', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/services')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.services.listServices().then(function(response) {
+      dnsimple.services.listServices().then(function (response) {
         var pagination = response.pagination;
         expect(pagination).to.not.be.null;
         expect(pagination.current_page).to.eq(1);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#allServices', function() {
-    it('produces a complete list', function(done) {
+  describe('#allServices', function () {
+    it('produces a complete list', function (done) {
       var fixture1 = testUtils.fixture('pages-1of3.http');
       nock('https://api.dnsimple.com')
         .get('/v2/services?page=1')
@@ -94,33 +94,33 @@ describe('services', function() {
         .get('/v2/services?page=3')
         .reply(fixture3.statusCode, fixture3.body);
 
-      dnsimple.services.allServices().then(function(items) {
+      dnsimple.services.allServices().then(function (items) {
         expect(items.length).to.eq(5);
         expect(items[0].id).to.eq(1);
         expect(items[4].id).to.eq(5);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
-      }).catch(function(error) {
+      }).catch(function (error) {
         done(error);
       });
     });
   });
 
-  describe('#getService', function() {
+  describe('#getService', function () {
     var serviceId = 1;
     var fixture = testUtils.fixture('getService/success.http');
 
-    it('produces a service', function(done) {
+    it('produces a service', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/services/1')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.services.getService(serviceId).then(function(response) {
+      dnsimple.services.getService(serviceId).then(function (response) {
         var service = response.data;
         expect(service.id).to.eq(1);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });

--- a/test/dnsimple/templates.spec.js
+++ b/test/dnsimple/templates.spec.js
@@ -2,86 +2,86 @@
 
 var testUtils = require('../testUtils');
 var dnsimple = require('../../lib/dnsimple')({
-  accessToken: testUtils.getAccessToken(),
+  accessToken: testUtils.getAccessToken()
 });
 
 const expect = require('chai').expect;
 const nock = require('nock');
 
-describe('templates', function() {
-  describe('#listTemplates', function() {
+describe('templates', function () {
+  describe('#listTemplates', function () {
     var accountId = '1010';
     var fixture = testUtils.fixture('listTemplates/success.http');
 
-    it('supports pagination', function(done) {
+    it('supports pagination', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/templates?page=1')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.templates.listTemplates(accountId, {page: 1});
+      dnsimple.templates.listTemplates(accountId, { page: 1 });
 
       nock.isDone();
       done();
     });
 
-    it('supports extra request options', function(done) {
+    it('supports extra request options', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/templates?foo=bar')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.templates.listTemplates(accountId, {query: {foo: 'bar'}});
+      dnsimple.templates.listTemplates(accountId, { query: { foo: 'bar' } });
 
       nock.isDone();
       done();
     });
 
-    it('supports sorting', function(done) {
+    it('supports sorting', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/templates?sort=name%3Aasc')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.templates.listTemplates(accountId, {sort: 'name:asc'});
+      dnsimple.templates.listTemplates(accountId, { sort: 'name:asc' });
 
       nock.isDone();
       done();
     });
 
-    it('produces a template list', function(done) {
+    it('produces a template list', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/templates')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.templates.listTemplates(accountId).then(function(response) {
+      dnsimple.templates.listTemplates(accountId).then(function (response) {
         var templates = response.data;
         expect(templates.length).to.eq(2);
         expect(templates[0].name).to.eq('Alpha');
         expect(templates[0].account_id).to.eq(1010);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    it('exposes the pagination info', function(done) {
+    it('exposes the pagination info', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/templates')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.templates.listTemplates(accountId).then(function(response) {
+      dnsimple.templates.listTemplates(accountId).then(function (response) {
         var pagination = response.pagination;
         expect(pagination).to.not.be.null;
         expect(pagination.current_page).to.eq(1);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#allTemplates', function() {
+  describe('#allTemplates', function () {
     var accountId = '1010';
 
-    it('produces a complete list', function(done) {
+    it('produces a complete list', function (done) {
       var fixture1 = testUtils.fixture('pages-1of3.http');
       nock('https://api.dnsimple.com')
         .get('/v2/1010/templates?page=1')
@@ -97,31 +97,31 @@ describe('templates', function() {
         .get('/v2/1010/templates?page=3')
         .reply(fixture3.statusCode, fixture3.body);
 
-      dnsimple.templates.allTemplates(accountId).then(function(items) {
+      dnsimple.templates.allTemplates(accountId).then(function (items) {
         expect(items.length).to.eq(5);
         expect(items[0].id).to.eq(1);
         expect(items[4].id).to.eq(5);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
-      }).catch(function(error) {
+      }).catch(function (error) {
         done(error);
       });
     });
   });
 
-  describe('#getTemplate', function() {
+  describe('#getTemplate', function () {
     var accountId = '1010';
     var templateId = 'name';
 
-    it('produces a template', function(done) {
+    it('produces a template', function (done) {
       var fixture = testUtils.fixture('getTemplate/success.http');
 
       nock('https://api.dnsimple.com')
         .get('/v2/1010/templates/name')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.templates.getTemplate(accountId, templateId).then(function(response) {
+      dnsimple.templates.getTemplate(accountId, templateId).then(function (response) {
         var template = response.data;
         expect(template.id).to.eq(1);
         expect(template.account_id).to.eq(1010);
@@ -131,22 +131,22 @@ describe('templates', function() {
         expect(template.created_at).to.eq('2016-03-22T11:08:58Z');
         expect(template.updated_at).to.eq('2016-03-22T11:08:58Z');
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    describe('when the template does not exist', function() {
-      it('produces an error', function(done) {
+    describe('when the template does not exist', function () {
+      it('produces an error', function (done) {
         var fixture = testUtils.fixture('notfound-template.http');
 
         nock('https://api.dnsimple.com')
           .get('/v2/1010/templates/name')
           .reply(fixture.statusCode, fixture.body);
 
-        dnsimple.templates.getTemplate(accountId, templateId).then(function(response) {
+        dnsimple.templates.getTemplate(accountId, templateId).then(function (response) {
           done();
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           expect(error.description).to.eq('Not found');
           expect(error.message).to.eq('Template `beta` not found');
@@ -156,14 +156,14 @@ describe('templates', function() {
     });
   });
 
-  describe('#createTemplate', function() {
+  describe('#createTemplate', function () {
     var accountId = '1010';
-    var attributes = {name: 'Beta'};
+    var attributes = { name: 'Beta' };
     var fixture = testUtils.fixture('createTemplate/created.http');
 
-    it('builds the correct request', function(done) {
+    it('builds the correct request', function (done) {
       nock('https://api.dnsimple.com')
-        .post('/v2/1010/templates', {name: 'Beta'})
+        .post('/v2/1010/templates', { name: 'Beta' })
         .reply(fixture.statusCode, fixture.body);
 
       dnsimple.templates.createTemplate(accountId, attributes);
@@ -172,30 +172,30 @@ describe('templates', function() {
       done();
     });
 
-    it('produces a template', function(done) {
+    it('produces a template', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/1010/templates')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.templates.createTemplate(accountId, attributes).then(function(response) {
+      dnsimple.templates.createTemplate(accountId, attributes).then(function (response) {
         var template = response.data;
         expect(template.id).to.eq(1);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#updateTemplate', function() {
+  describe('#updateTemplate', function () {
     var accountId = '1010';
     var templateId = 1;
-    var attributes = {name: 'Alpha'};
+    var attributes = { name: 'Alpha' };
     var fixture = testUtils.fixture('updateTemplate/success.http');
 
-    it('builds the correct request', function(done) {
+    it('builds the correct request', function (done) {
       nock('https://api.dnsimple.com')
-        .patch('/v2/1010/templates/1', {name: 'Alpha'})
+        .patch('/v2/1010/templates/1', { name: 'Alpha' })
         .reply(fixture.statusCode, fixture.body);
 
       dnsimple.templates.updateTemplate(accountId, templateId, attributes);
@@ -204,31 +204,31 @@ describe('templates', function() {
       done();
     });
 
-    it('produces a template', function(done) {
+    it('produces a template', function (done) {
       nock('https://api.dnsimple.com')
         .patch('/v2/1010/templates/1')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.templates.updateTemplate(accountId, templateId, attributes).then(function(response) {
+      dnsimple.templates.updateTemplate(accountId, templateId, attributes).then(function (response) {
         var template = response.data;
         expect(template.id).to.eq(1);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    describe('when the template does not exist', function() {
-      it('produces an error', function(done) {
+    describe('when the template does not exist', function () {
+      it('produces an error', function (done) {
         var fixture = testUtils.fixture('notfound-template.http');
 
         nock('https://api.dnsimple.com')
           .patch('/v2/1010/templates/0')
           .reply(fixture.statusCode, fixture.body);
 
-        dnsimple.templates.updateTemplate(accountId, templateId, attributes).then(function(response) {
+        dnsimple.templates.updateTemplate(accountId, templateId, attributes).then(function (response) {
           done();
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           done();
         });
@@ -236,121 +236,120 @@ describe('templates', function() {
     });
   });
 
-  describe('#deleteTemplate', function() {
+  describe('#deleteTemplate', function () {
     var accountId = '1010';
     var templateId = 1;
     var fixture = testUtils.fixture('deleteTemplate/success.http');
 
-    it('produces nothing', function(done) {
+    it('produces nothing', function (done) {
       nock('https://api.dnsimple.com')
         .delete('/v2/1010/templates/1')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.templates.deleteTemplate(accountId, templateId).then(function(response) {
+      dnsimple.templates.deleteTemplate(accountId, templateId).then(function (response) {
         expect(response).to.eql({});
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#applyTemplate', function() {
+  describe('#applyTemplate', function () {
     var accountId = '1010';
-    var domainId = 'example.com'
+    var domainId = 'example.com';
     var templateId = 1;
     var fixture = testUtils.fixture('applyTemplate/success.http');
 
-    it('produces nothing', function(done) {
+    it('produces nothing', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/1010/domains/example.com/templates/1')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.templates.applyTemplate(accountId, templateId, domainId).then(function(response) {
+      dnsimple.templates.applyTemplate(accountId, templateId, domainId).then(function (response) {
         expect(response).to.eql({});
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
-
 });
 
-describe('template records', function() {
-  describe('#listTemplateRecords', function() {
+describe('template records', function () {
+  describe('#listTemplateRecords', function () {
     var accountId = '1010';
     var templateId = '1';
     var fixture = testUtils.fixture('listTemplateRecords/success.http');
 
-    it('supports pagination', function(done) {
+    it('supports pagination', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/templates/1/records?page=1')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.templates.listTemplateRecords(accountId, templateId, {page: 1});
+      dnsimple.templates.listTemplateRecords(accountId, templateId, { page: 1 });
 
       nock.isDone();
       done();
     });
 
-    it('supports extra request options', function(done) {
+    it('supports extra request options', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/templates/1/records?foo=bar')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.templates.listTemplateRecords(accountId, templateId, {query: {foo: 'bar'}});
+      dnsimple.templates.listTemplateRecords(accountId, templateId, { query: { foo: 'bar' } });
 
       nock.isDone();
       done();
     });
 
-    it('supports sorting', function(done) {
+    it('supports sorting', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/templates/1/records?sort=name%3Aasc')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.templates.listTemplateRecords(accountId, templateId, {sort: 'name:asc'});
+      dnsimple.templates.listTemplateRecords(accountId, templateId, { sort: 'name:asc' });
 
       nock.isDone();
       done();
     });
 
-    it('produces a template list', function(done) {
+    it('produces a template list', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/templates/1/records')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.templates.listTemplateRecords(accountId, templateId).then(function(response) {
+      dnsimple.templates.listTemplateRecords(accountId, templateId).then(function (response) {
         var records = response.data;
         expect(records.length).to.eq(2);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    it('exposes the pagination info', function(done) {
+    it('exposes the pagination info', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/templates/1/records')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.templates.listTemplateRecords(accountId, templateId).then(function(response) {
+      dnsimple.templates.listTemplateRecords(accountId, templateId).then(function (response) {
         var pagination = response.pagination;
         expect(pagination).to.not.be.null;
         expect(pagination.current_page).to.eq(1);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#allRecords', function() {
+  describe('#allRecords', function () {
     var accountId = '1010';
     var templateId = 1;
 
-    it('produces a complete list', function(done) {
+    it('produces a complete list', function (done) {
       var fixture1 = testUtils.fixture('pages-1of3.http');
       nock('https://api.dnsimple.com')
         .get('/v2/1010/templates/1/records?page=1')
@@ -366,32 +365,32 @@ describe('template records', function() {
         .get('/v2/1010/templates/1/records?page=3')
         .reply(fixture3.statusCode, fixture3.body);
 
-      dnsimple.templates.allTemplateRecords(accountId, templateId).then(function(items) {
+      dnsimple.templates.allTemplateRecords(accountId, templateId).then(function (items) {
         expect(items.length).to.eq(5);
         expect(items[0].id).to.eq(1);
         expect(items[4].id).to.eq(5);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
-      }).catch(function(error) {
+      }).catch(function (error) {
         done(error);
       });
     });
   });
 
-  describe('#getTemplateRecord', function() {
+  describe('#getTemplateRecord', function () {
     var accountId = '1010';
     var templateId = 'name';
     var recordId = 1;
 
-    it('produces a template', function(done) {
+    it('produces a template', function (done) {
       var fixture = testUtils.fixture('getTemplateRecord/success.http');
 
       nock('https://api.dnsimple.com')
         .get('/v2/1010/templates/name/records/1')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.templates.getTemplateRecord(accountId, templateId, recordId).then(function(response) {
+      dnsimple.templates.getTemplateRecord(accountId, templateId, recordId).then(function (response) {
         var record = response.data;
         expect(record.id).to.eq(301);
         expect(record.template_id).to.eq(268);
@@ -403,22 +402,22 @@ describe('template records', function() {
         expect(record.created_at).to.eq('2016-05-03T08:03:26Z');
         expect(record.updated_at).to.eq('2016-05-03T08:03:26Z');
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    describe('when the template does not exist', function() {
-      it('produces an error', function(done) {
+    describe('when the template does not exist', function () {
+      it('produces an error', function (done) {
         var fixture = testUtils.fixture('notfound-template.http');
 
         nock('https://api.dnsimple.com')
           .get('/v2/1010/templates/0/records/1')
           .reply(fixture.statusCode, fixture.body);
 
-        dnsimple.templates.getTemplateRecord(accountId, 0, recordId).then(function(response) {
+        dnsimple.templates.getTemplateRecord(accountId, 0, recordId).then(function (response) {
           done();
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           expect(error.description).to.eq('Not found');
           expect(error.message).to.eq('Template `beta` not found');
@@ -427,17 +426,17 @@ describe('template records', function() {
       });
     });
 
-    describe('when the template record does not exist', function() {
-      it('produces an error', function(done) {
+    describe('when the template record does not exist', function () {
+      it('produces an error', function (done) {
         var fixture = testUtils.fixture('notfound-record.http');
 
         nock('https://api.dnsimple.com')
           .get('/v2/1010/templates/name/records/0')
           .reply(fixture.statusCode, fixture.body);
 
-        dnsimple.templates.getTemplateRecord(accountId, templateId, 0).then(function(response) {
+        dnsimple.templates.getTemplateRecord(accountId, templateId, 0).then(function (response) {
           done();
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           done();
         });
@@ -445,15 +444,15 @@ describe('template records', function() {
     });
   });
 
-  describe('#createTemplateRecord', function() {
+  describe('#createTemplateRecord', function () {
     var accountId = '1010';
     var templateId = 1;
-    var attributes = {content: 'mx.example.com'};
+    var attributes = { content: 'mx.example.com' };
     var fixture = testUtils.fixture('createTemplateRecord/created.http');
 
-    it('builds the correct request', function(done) {
+    it('builds the correct request', function (done) {
       nock('https://api.dnsimple.com')
-        .post('/v2/1010/templates/1/records', {content: 'mx.example.com'})
+        .post('/v2/1010/templates/1/records', { content: 'mx.example.com' })
         .reply(fixture.statusCode, fixture.body);
 
       dnsimple.templates.createTemplateRecord(accountId, templateId, attributes);
@@ -462,36 +461,36 @@ describe('template records', function() {
       done();
     });
 
-    it('produces a record', function(done) {
+    it('produces a record', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/1010/templates/1/records')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.templates.createTemplateRecord(accountId, templateId, attributes).then(function(response) {
+      dnsimple.templates.createTemplateRecord(accountId, templateId, attributes).then(function (response) {
         var record = response.data;
         expect(record.id).to.eq(300);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#deleteTemplateRecord', function() {
+  describe('#deleteTemplateRecord', function () {
     var accountId = '1010';
     var templateId = 1;
     var recordId = 2;
     var fixture = testUtils.fixture('deleteTemplateRecord/success.http');
 
-    it('produces nothing', function(done) {
+    it('produces nothing', function (done) {
       nock('https://api.dnsimple.com')
         .delete('/v2/1010/templates/1/records/2')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.templates.deleteTemplateRecord(accountId, templateId, recordId).then(function(response) {
+      dnsimple.templates.deleteTemplateRecord(accountId, templateId, recordId).then(function (response) {
         expect(response).to.eql({});
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });

--- a/test/dnsimple/templates.spec.js
+++ b/test/dnsimple/templates.spec.js
@@ -69,7 +69,7 @@ describe('templates', function () {
 
       dnsimple.templates.listTemplates(accountId).then(function (response) {
         var pagination = response.pagination;
-        expect(pagination).to.not.be.null;
+        expect(pagination).to.not.eq(null);
         expect(pagination.current_page).to.eq(1);
         done();
       }, function (error) {
@@ -147,7 +147,7 @@ describe('templates', function () {
         dnsimple.templates.getTemplate(accountId, templateId).then(function (response) {
           done();
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           expect(error.description).to.eq('Not found');
           expect(error.message).to.eq('Template `beta` not found');
           done();
@@ -229,7 +229,7 @@ describe('templates', function () {
         dnsimple.templates.updateTemplate(accountId, templateId, attributes).then(function (response) {
           done();
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           done();
         });
       });
@@ -336,7 +336,7 @@ describe('template records', function () {
 
       dnsimple.templates.listTemplateRecords(accountId, templateId).then(function (response) {
         var pagination = response.pagination;
-        expect(pagination).to.not.be.null;
+        expect(pagination).to.not.eq(null);
         expect(pagination.current_page).to.eq(1);
         done();
       }, function (error) {
@@ -418,7 +418,7 @@ describe('template records', function () {
         dnsimple.templates.getTemplateRecord(accountId, 0, recordId).then(function (response) {
           done();
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           expect(error.description).to.eq('Not found');
           expect(error.message).to.eq('Template `beta` not found');
           done();
@@ -437,7 +437,7 @@ describe('template records', function () {
         dnsimple.templates.getTemplateRecord(accountId, templateId, 0).then(function (response) {
           done();
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           done();
         });
       });

--- a/test/dnsimple/tlds.spec.js
+++ b/test/dnsimple/tlds.spec.js
@@ -133,15 +133,15 @@ describe('tlds', function () {
         .reply(fixture.statusCode, fixture.body);
 
       dnsimple.tlds.getTldExtendedAttributes('uk').then(function (response) {
-        var extended_attributes = response.data;
-        expect(extended_attributes.length).to.eq(4);
-        expect(extended_attributes[0].name).to.eq('uk_legal_type');
-        expect(extended_attributes[0].description).to.eq('Legal type of registrant contact');
-        expect(extended_attributes[0].required).to.be.false;
-        expect(extended_attributes[0].options.length).to.eq(17);
-        expect(extended_attributes[0].options[0].title).to.eq('UK Individual');
-        expect(extended_attributes[0].options[0].value).to.eq('IND');
-        expect(extended_attributes[0].options[0].description).to.eq('UK Individual (our default value)');
+        var extendedAttributes = response.data;
+        expect(extendedAttributes.length).to.eq(4);
+        expect(extendedAttributes[0].name).to.eq('uk_legal_type');
+        expect(extendedAttributes[0].description).to.eq('Legal type of registrant contact');
+        expect(extendedAttributes[0].required).to.be.false;
+        expect(extendedAttributes[0].options.length).to.eq(17);
+        expect(extendedAttributes[0].options[0].title).to.eq('UK Individual');
+        expect(extendedAttributes[0].options[0].value).to.eq('IND');
+        expect(extendedAttributes[0].options[0].description).to.eq('UK Individual (our default value)');
         done();
       }, function (error) {
         done(error);

--- a/test/dnsimple/tlds.spec.js
+++ b/test/dnsimple/tlds.spec.js
@@ -2,82 +2,82 @@
 
 var testUtils = require('../testUtils');
 var dnsimple = require('../../lib/dnsimple')({
-  accessToken: testUtils.getAccessToken(),
+  accessToken: testUtils.getAccessToken()
 });
 
 const expect = require('chai').expect;
 const nock = require('nock');
 
-describe('tlds', function() {
-  describe('#listTlds', function() {
+describe('tlds', function () {
+  describe('#listTlds', function () {
     var fixture = testUtils.fixture('listTlds/success.http');
 
-    it('supports pagination', function(done) {
+    it('supports pagination', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/tlds?page=1')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.tlds.listTlds({page: 1});
+      dnsimple.tlds.listTlds({ page: 1 });
 
       nock.isDone();
       done();
     });
 
-    it('supports extra request options', function(done) {
+    it('supports extra request options', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/tlds?foo=bar')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.tlds.listTlds({query: {foo: 'bar'}});
+      dnsimple.tlds.listTlds({ query: { foo: 'bar' } });
 
       nock.isDone();
       done();
     });
 
-    it('supports sorting', function(done) {
+    it('supports sorting', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/tlds?sort=tld%3Aasc')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.tlds.listTlds({sort: 'tld:asc'});
+      dnsimple.tlds.listTlds({ sort: 'tld:asc' });
 
       nock.isDone();
       done();
     });
 
-    it('produces a tld list', function(done) {
+    it('produces a tld list', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/tlds')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.tlds.listTlds().then(function(response) {
+      dnsimple.tlds.listTlds().then(function (response) {
         var tlds = response.data;
         expect(tlds.length).to.eq(2);
         expect(tlds[0].tld).to.eq('ac');
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    it('exposes the pagination info', function(done) {
+    it('exposes the pagination info', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/tlds')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.tlds.listTlds().then(function(response) {
+      dnsimple.tlds.listTlds().then(function (response) {
         var pagination = response.pagination;
         expect(pagination).to.not.be.null;
         expect(pagination.current_page).to.eq(1);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#allTlds', function() {
-    it('produces a complete list', function(done) {
+  describe('#allTlds', function () {
+    it('produces a complete list', function (done) {
       var fixture1 = testUtils.fixture('pages-1of3.http');
       nock('https://api.dnsimple.com')
         .get('/v2/tlds?page=1')
@@ -93,48 +93,48 @@ describe('tlds', function() {
         .get('/v2/tlds?page=3')
         .reply(fixture3.statusCode, fixture3.body);
 
-      dnsimple.tlds.allTlds().then(function(items) {
+      dnsimple.tlds.allTlds().then(function (items) {
         expect(items.length).to.eq(5);
         expect(items[0].id).to.eq(1);
         expect(items[4].id).to.eq(5);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
-      }).catch(function(error) {
+      }).catch(function (error) {
         done(error);
       });
     });
   });
 
-  describe('#getTld', function() {
+  describe('#getTld', function () {
     var fixture = testUtils.fixture('getTld/success.http');
 
-    it('produces a tld', function(done) {
+    it('produces a tld', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/tlds/com')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.tlds.getTld('com').then(function(response) {
+      dnsimple.tlds.getTld('com').then(function (response) {
         var tld = response.data;
         expect(tld.tld).to.eq('com');
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#getTldExtendedAttributes', function() {
-    it('produces a collection of extended attributes', function(done) {
+  describe('#getTldExtendedAttributes', function () {
+    it('produces a collection of extended attributes', function (done) {
       var fixture = testUtils.fixture('getTldExtendedAttributes/success.http');
 
       nock('https://api.dnsimple.com')
         .get('/v2/tlds/uk/extended_attributes')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.tlds.getTldExtendedAttributes('uk').then(function(response) {
+      dnsimple.tlds.getTldExtendedAttributes('uk').then(function (response) {
         var extended_attributes = response.data;
-        expect(extended_attributes.length).to.eq(4)
+        expect(extended_attributes.length).to.eq(4);
         expect(extended_attributes[0].name).to.eq('uk_legal_type');
         expect(extended_attributes[0].description).to.eq('Legal type of registrant contact');
         expect(extended_attributes[0].required).to.be.false;
@@ -143,27 +143,26 @@ describe('tlds', function() {
         expect(extended_attributes[0].options[0].value).to.eq('IND');
         expect(extended_attributes[0].options[0].description).to.eq('UK Individual (our default value)');
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    describe('when there are no extended attributes for a TLD', function() {
+    describe('when there are no extended attributes for a TLD', function () {
       var fixture = testUtils.fixture('getTldExtendedAttributes/success-noattributes.http');
 
-      it('returns an empty collection', function(done) {
+      it('returns an empty collection', function (done) {
         nock('https://api.dnsimple.com')
           .get('/v2/tlds/com/extended_attributes')
           .reply(fixture.statusCode, fixture.body);
 
-        dnsimple.tlds.getTldExtendedAttributes('com').then(function(response) {
+        dnsimple.tlds.getTldExtendedAttributes('com').then(function (response) {
           expect(response.data).to.eql([]);
           done();
-        }, function(error) {
+        }, function (error) {
           done(error);
         });
       });
     });
   });
-
 });

--- a/test/dnsimple/tlds.spec.js
+++ b/test/dnsimple/tlds.spec.js
@@ -67,7 +67,7 @@ describe('tlds', function () {
 
       dnsimple.tlds.listTlds().then(function (response) {
         var pagination = response.pagination;
-        expect(pagination).to.not.be.null;
+        expect(pagination).to.not.eq(null);
         expect(pagination.current_page).to.eq(1);
         done();
       }, function (error) {
@@ -137,7 +137,7 @@ describe('tlds', function () {
         expect(extendedAttributes.length).to.eq(4);
         expect(extendedAttributes[0].name).to.eq('uk_legal_type');
         expect(extendedAttributes[0].description).to.eq('Legal type of registrant contact');
-        expect(extendedAttributes[0].required).to.be.false;
+        expect(extendedAttributes[0].required).to.eq(false);
         expect(extendedAttributes[0].options.length).to.eq(17);
         expect(extendedAttributes[0].options[0].title).to.eq('UK Individual');
         expect(extendedAttributes[0].options[0].value).to.eq('IND');

--- a/test/dnsimple/vanity_name_servers.spec.js
+++ b/test/dnsimple/vanity_name_servers.spec.js
@@ -2,25 +2,25 @@
 
 var testUtils = require('../testUtils');
 var dnsimple = require('../../lib/dnsimple')({
-  accessToken: testUtils.getAccessToken(),
+  accessToken: testUtils.getAccessToken()
 });
 
 const expect = require('chai').expect;
 const nock = require('nock');
 
-describe('vanity name servers', function() {
-  let accountId = '1010';
-  let domainId = 'example.com';
+describe('vanity name servers', function () {
+  const accountId = '1010';
+  const domainId = 'example.com';
 
-  describe('#enableVanityNameServers', function() {
+  describe('#enableVanityNameServers', function () {
     var fixture = testUtils.fixture('enableVanityNameServers/success.http');
 
-    it('produces a list of name servers', function(done) {
+    it('produces a list of name servers', function (done) {
       nock('https://api.dnsimple.com')
         .put('/v2/1010/vanity/example.com')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.vanityNameServers.enableVanityNameServers(accountId, domainId).then(function(response) {
+      dnsimple.vanityNameServers.enableVanityNameServers(accountId, domainId).then(function (response) {
         var vanityNameServers = response.data;
         expect(vanityNameServers.length).to.eq(4);
         expect(vanityNameServers[0].id).to.eq(1);
@@ -29,24 +29,24 @@ describe('vanity name servers', function() {
         expect(vanityNameServers[0].created_at).to.eq('2016-07-14T13:22:17Z');
         expect(vanityNameServers[0].updated_at).to.eq('2016-07-14T13:22:17Z');
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#disableVanityNameServers', function() {
+  describe('#disableVanityNameServers', function () {
     var fixture = testUtils.fixture('disableVanityNameServers/success.http');
 
-    it('produces nothing', function(done) {
+    it('produces nothing', function (done) {
       nock('https://api.dnsimple.com')
         .delete('/v2/1010/vanity/example.com')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.vanityNameServers.disableVanityNameServers(accountId, domainId).then(function(response) {
+      dnsimple.vanityNameServers.disableVanityNameServers(accountId, domainId).then(function (response) {
         expect(response).to.eql({});
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });

--- a/test/dnsimple/webhooks.spec.js
+++ b/test/dnsimple/webhooks.spec.js
@@ -2,104 +2,104 @@
 
 var testUtils = require('../testUtils');
 var dnsimple = require('../../lib/dnsimple')({
-  accessToken: testUtils.getAccessToken(),
+  accessToken: testUtils.getAccessToken()
 });
 
 const expect = require('chai').expect;
 const nock = require('nock');
 
-describe('webhooks', function() {
-  describe('#listWebhooks', function() {
+describe('webhooks', function () {
+  describe('#listWebhooks', function () {
     var accountId = '1010';
     var fixture = testUtils.fixture('listDomains/success.http');
 
-    it('supports extra request options', function(done) {
+    it('supports extra request options', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/webhooks?foo=bar')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.webhooks.listWebhooks(accountId, {query: {foo: 'bar'}});
+      dnsimple.webhooks.listWebhooks(accountId, { query: { foo: 'bar' } });
 
       nock.isDone();
       done();
     });
 
-    it('produces a webhook list', function(done) {
+    it('produces a webhook list', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/webhooks')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.webhooks.listWebhooks(accountId).then(function(response) {
+      dnsimple.webhooks.listWebhooks(accountId).then(function (response) {
         var webhooks = response.data;
         expect(webhooks.length).to.eq(2);
         expect(webhooks[0].id).to.eq(1);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#allWebhooks', function() {
+  describe('#allWebhooks', function () {
     var accountId = '1010';
     var fixture = testUtils.fixture('listDomains/success.http');
 
-    it('supports extra request options', function(done) {
+    it('supports extra request options', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/webhooks?foo=bar')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.webhooks.allWebhooks(accountId, {query: {foo: 'bar'}});
+      dnsimple.webhooks.allWebhooks(accountId, { query: { foo: 'bar' } });
 
       nock.isDone();
       done();
     });
 
-    it('produces a webhook list', function(done) {
+    it('produces a webhook list', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/webhooks')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.webhooks.allWebhooks(accountId).then(function(items) {
+      dnsimple.webhooks.allWebhooks(accountId).then(function (items) {
         expect(items.length).to.eq(2);
         expect(items[0].id).to.eq(1);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#getWebhook', function() {
+  describe('#getWebhook', function () {
     var accountId = '1010';
     var webhookId = '1';
     var fixture = testUtils.fixture('getWebhook/success.http');
 
-    it('produces a webhook', function(done) {
+    it('produces a webhook', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/webhooks/1')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.webhooks.getWebhook(accountId, webhookId).then(function(response) {
+      dnsimple.webhooks.getWebhook(accountId, webhookId).then(function (response) {
         var webhook = response.data;
         expect(webhook.id).to.eq(1);
         expect(webhook.url).to.eq('https://webhook.test');
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    describe('when the webhook does not exist', function() {
+    describe('when the webhook does not exist', function () {
       var fixture = testUtils.fixture('notfound-webhook.http');
       nock('https://api.dnsimple.com')
         .get('/v2/1010/webhooks/0')
         .reply(fixture.statusCode, fixture.body);
 
-      it('produces an error', function(done) {
-        dnsimple.webhooks.getWebhook(accountId, 0).then(function(response) {
+      it('produces an error', function (done) {
+        dnsimple.webhooks.getWebhook(accountId, 0).then(function (response) {
           done();
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           expect(error.description).to.eq('Not found');
           expect(error.message).to.eq('Webhook `0` not found');
@@ -109,12 +109,12 @@ describe('webhooks', function() {
     });
   });
 
-  describe('#createWebhook', function() {
+  describe('#createWebhook', function () {
     var accountId = '1010';
-    var attributes = {url: 'https://some-site.com'};
+    var attributes = { url: 'https://some-site.com' };
     var fixture = testUtils.fixture('createWebhook/created.http');
 
-    it('builds the correct request', function(done) {
+    it('builds the correct request', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/1010/webhooks', attributes)
         .reply(fixture.statusCode, fixture.body);
@@ -125,49 +125,49 @@ describe('webhooks', function() {
       done();
     });
 
-    it('produces a webhook', function(done) {
+    it('produces a webhook', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/1010/webhooks')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.webhooks.createWebhook(accountId, attributes).then(function(response) {
+      dnsimple.webhooks.createWebhook(accountId, attributes).then(function (response) {
         var webhook = response.data;
         expect(webhook.id).to.eq(1);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#deleteWebhook', function() {
+  describe('#deleteWebhook', function () {
     var accountId = '1010';
     var webhookId = 1;
 
-    it('produces nothing', function(done) {
+    it('produces nothing', function (done) {
       var fixture = testUtils.fixture('deleteWebhook/success.http');
       nock('https://api.dnsimple.com')
         .delete('/v2/1010/webhooks/1')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.webhooks.deleteWebhook(accountId, webhookId).then(function(response) {
+      dnsimple.webhooks.deleteWebhook(accountId, webhookId).then(function (response) {
         expect(response).to.eql({});
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    describe('when the webhook does not exist', function() {
+    describe('when the webhook does not exist', function () {
       var fixture = testUtils.fixture('notfound-webhook.http');
       nock('https://api.dnsimple.com')
         .get('/v2/1010/webhooks/0')
         .reply(fixture.statusCode, fixture.body);
 
-      it('produces an error', function(done) {
-        dnsimple.webhooks.deleteWebhook(accountId, 0).then(function(response) {
+      it('produces an error', function (done) {
+        dnsimple.webhooks.deleteWebhook(accountId, 0).then(function (response) {
           done();
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           done();
         });

--- a/test/dnsimple/webhooks.spec.js
+++ b/test/dnsimple/webhooks.spec.js
@@ -100,7 +100,7 @@ describe('webhooks', function () {
         dnsimple.webhooks.getWebhook(accountId, 0).then(function (response) {
           done();
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           expect(error.description).to.eq('Not found');
           expect(error.message).to.eq('Webhook `0` not found');
           done();
@@ -168,7 +168,7 @@ describe('webhooks', function () {
         dnsimple.webhooks.deleteWebhook(accountId, 0).then(function (response) {
           done();
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           done();
         });
       });

--- a/test/dnsimple/zone_records.spec.js
+++ b/test/dnsimple/zone_records.spec.js
@@ -2,68 +2,68 @@
 
 var testUtils = require('../testUtils');
 var dnsimple = require('../../lib/dnsimple')({
-  accessToken: testUtils.getAccessToken(),
+  accessToken: testUtils.getAccessToken()
 });
 
 const expect = require('chai').expect;
 const nock = require('nock');
 
-describe('zone records', function() {
-  describe('#listZoneRecords', function() {
+describe('zone records', function () {
+  describe('#listZoneRecords', function () {
     var accountId = '1010';
     var zoneId = 'example.com';
     var fixture = testUtils.fixture('listZoneRecords/success.http');
 
-    it('supports pagination', function(done) {
+    it('supports pagination', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/zones/example.com/records?page=1')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.zones.listZoneRecords(accountId, zoneId, {page: 1});
+      dnsimple.zones.listZoneRecords(accountId, zoneId, { page: 1 });
 
       nock.isDone();
       done();
     });
 
-    it('supports extra request options', function(done) {
+    it('supports extra request options', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/zones/example.com/records?foo=bar')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.zones.listZoneRecords(accountId, zoneId, {query: {foo: 'bar'}});
+      dnsimple.zones.listZoneRecords(accountId, zoneId, { query: { foo: 'bar' } });
 
       nock.isDone();
       done();
     });
 
-    it('supports sorting', function(done) {
+    it('supports sorting', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/zones/example.com/records?sort=name%3Aasc')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.zones.listZoneRecords(accountId, zoneId, {sort: 'name:asc'});
+      dnsimple.zones.listZoneRecords(accountId, zoneId, { sort: 'name:asc' });
 
       nock.isDone();
       done();
     });
 
-    it('supports filter', function(done) {
+    it('supports filter', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/zones/example.com/records?name_like=example')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.zones.listZoneRecords(accountId, zoneId, {filter: {name_like: 'example'}});
+      dnsimple.zones.listZoneRecords(accountId, zoneId, { filter: { name_like: 'example' } });
 
       nock.isDone();
       done();
     });
 
-    it('produces a record list', function(done) {
+    it('produces a record list', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/zones/example.com/records')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.zones.listZoneRecords(accountId, zoneId).then(function(response) {
+      dnsimple.zones.listZoneRecords(accountId, zoneId).then(function (response) {
         var records = response.data;
         expect(records.length).to.eq(5);
         expect(records[0].id).to.eq(1);
@@ -77,32 +77,32 @@ describe('zone records', function() {
         expect(records[0].created_at).to.eq('2016-03-22T10:20:53Z');
         expect(records[0].updated_at).to.eq('2016-10-05T09:26:38Z');
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    it('exposes the pagination info', function(done) {
+    it('exposes the pagination info', function (done) {
       nock('https://api.dnsimple.com')
         .get(`/v2/1010/zones/${zoneId}/records`)
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.zones.listZoneRecords(accountId, zoneId).then(function(response) {
+      dnsimple.zones.listZoneRecords(accountId, zoneId).then(function (response) {
         var pagination = response.pagination;
         expect(pagination).to.not.be.null;
         expect(pagination.current_page).to.eq(1);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#allZoneRecords', function() {
+  describe('#allZoneRecords', function () {
     var accountId = '1010';
     var zoneId = 'example.com';
 
-    it('produces a complete list', function(done) {
+    it('produces a complete list', function (done) {
       var fixture1 = testUtils.fixture('pages-1of3.http');
       nock('https://api.dnsimple.com')
         .get('/v2/1010/zones/example.com/records?page=1')
@@ -118,51 +118,51 @@ describe('zone records', function() {
         .get('/v2/1010/zones/example.com/records?page=3')
         .reply(fixture3.statusCode, fixture3.body);
 
-      dnsimple.zones.allZoneRecords(accountId, zoneId).then(function(items) {
+      dnsimple.zones.allZoneRecords(accountId, zoneId).then(function (items) {
         expect(items.length).to.eq(5);
         expect(items[0].id).to.eq(1);
         expect(items[4].id).to.eq(5);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
-      }).catch(function(error) {
+      }).catch(function (error) {
         done(error);
       });
     });
   });
 
-  describe('#getZoneRecord', function() {
+  describe('#getZoneRecord', function () {
     var accountId = '1010';
     var zoneId = 'example.com';
     var fixture = testUtils.fixture('getZoneRecord/success.http');
 
-    it('produces a record', function(done) {
+    it('produces a record', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/zones/example.com/records/64784')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.zones.getZoneRecord(accountId, zoneId, 64784).then(function(response) {
+      dnsimple.zones.getZoneRecord(accountId, zoneId, 64784).then(function (response) {
         var record = response.data;
         expect(record.id).to.eq(5);
         expect(record.regions.length).to.eq(2);
         expect(record.regions[0]).to.eq('SV1');
         expect(record.regions[1]).to.eq('IAD');
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    describe('when the record does not exist', function() {
+    describe('when the record does not exist', function () {
       var fixture = testUtils.fixture('notfound-record.http');
       nock('https://api.dnsimple.com')
         .get('/v2/1010/zones/example.com/records/0')
         .reply(fixture.statusCode, fixture.body);
 
-      it('produces an error', function(done) {
-        dnsimple.zones.getZoneRecord(accountId, zoneId, '0').then(function(response) {
+      it('produces an error', function (done) {
+        dnsimple.zones.getZoneRecord(accountId, zoneId, '0').then(function (response) {
           done('Error expected but future resolved');
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           expect(error.description).to.eq('Not found');
           expect(error.message).to.eq('Record `0` not found');
@@ -172,13 +172,13 @@ describe('zone records', function() {
     });
   });
 
-  describe('#createZoneRecord', function() {
+  describe('#createZoneRecord', function () {
     var accountId = '1010';
     var zoneId = 'example.com';
-    var attributes = {name: '', type: 'A', ttl: 3600, content: '1.2.3.4'};
+    var attributes = { name: '', type: 'A', ttl: 3600, content: '1.2.3.4' };
     var fixture = testUtils.fixture('createZoneRecord/created.http');
 
-    it('builds the correct request', function(done) {
+    it('builds the correct request', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/1010/zones/example.com/records', attributes)
         .reply(fixture.statusCode, fixture.body);
@@ -189,29 +189,29 @@ describe('zone records', function() {
       done();
     });
 
-    it('produces a record', function(done) {
+    it('produces a record', function (done) {
       nock('https://api.dnsimple.com')
         .post('/v2/1010/zones/example.com/records', attributes)
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.zones.createZoneRecord(accountId, zoneId, attributes).then(function(response) {
+      dnsimple.zones.createZoneRecord(accountId, zoneId, attributes).then(function (response) {
         var record = response.data;
         expect(record.id).to.eq(1);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#updateZoneRecord', function() {
+  describe('#updateZoneRecord', function () {
     var accountId = '1010';
     var zoneId = 'example.com';
     var recordId = 64784;
-    var attributes = {content: '127.0.0.1'};
+    var attributes = { content: '127.0.0.1' };
     var fixture = testUtils.fixture('updateZoneRecord/success.http');
 
-    it('builds the correct request', function(done) {
+    it('builds the correct request', function (done) {
       nock('https://api.dnsimple.com')
         .patch('/v2/1010/zones/example.com/records/' + recordId, attributes)
         .reply(fixture.statusCode, fixture.body);
@@ -222,30 +222,30 @@ describe('zone records', function() {
       done();
     });
 
-    it('produces a record', function(done) {
+    it('produces a record', function (done) {
       nock('https://api.dnsimple.com')
         .patch('/v2/1010/zones/example.com/records/' + recordId, attributes)
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.zones.updateZoneRecord(accountId, zoneId, recordId, attributes).then(function(response) {
+      dnsimple.zones.updateZoneRecord(accountId, zoneId, recordId, attributes).then(function (response) {
         var record = response.data;
         expect(record.id).to.eq(5);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    describe('when the record does not exist', function() {
+    describe('when the record does not exist', function () {
       var fixture = testUtils.fixture('notfound-record.http');
       nock('https://api.dnsimple.com')
         .get('/v2/1010/zones/example.com/records/' + recordId, attributes)
         .reply(fixture.statusCode, fixture.body);
 
-      it('produces an error', function(done) {
-        dnsimple.zones.updateZoneRecord(accountId, zoneId, recordId, attributes).then(function(response) {
+      it('produces an error', function (done) {
+        dnsimple.zones.updateZoneRecord(accountId, zoneId, recordId, attributes).then(function (response) {
           done();
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           done();
         });
@@ -253,13 +253,13 @@ describe('zone records', function() {
     });
   });
 
-  describe('#deleteZoneRecord', function() {
+  describe('#deleteZoneRecord', function () {
     var accountId = '1010';
     var zoneId = 'example.com';
     var recordId = 64784;
     var fixture = testUtils.fixture('deleteZoneRecord/success.http');
 
-    it('builds the correct request', function(done) {
+    it('builds the correct request', function (done) {
       nock('https://api.dnsimple.com')
         .delete('/v2/1010/zones/example.com/records/' + recordId)
         .reply(fixture.statusCode, fixture.body);
@@ -270,34 +270,33 @@ describe('zone records', function() {
       done();
     });
 
-    it('produces nothing', function(done) {
+    it('produces nothing', function (done) {
       nock('https://api.dnsimple.com')
         .delete('/v2/1010/zones/example.com/records/' + recordId)
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.zones.deleteZoneRecord(accountId, zoneId, recordId).then(function(response) {
+      dnsimple.zones.deleteZoneRecord(accountId, zoneId, recordId).then(function (response) {
         expect(response).to.eql({});
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    describe('when the record does not exist', function() {
-      it('produces an error', function(done) {
+    describe('when the record does not exist', function () {
+      it('produces an error', function (done) {
         var fixture = testUtils.fixture('notfound-record.http');
         nock('https://api.dnsimple.com')
           .delete('/v2/1010/zones/example.com/records/' + recordId)
           .reply(fixture.statusCode, fixture.body);
 
-        dnsimple.zones.deleteZoneRecord(accountId, zoneId, recordId).then(function(response) {
+        dnsimple.zones.deleteZoneRecord(accountId, zoneId, recordId).then(function (response) {
           done('Error expected but future resolved');
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           done();
         });
       });
     });
-
   });
 });

--- a/test/dnsimple/zone_records.spec.js
+++ b/test/dnsimple/zone_records.spec.js
@@ -71,9 +71,9 @@ describe('zone records', function () {
         expect(records[0].name).to.eq('');
         expect(records[0].content).to.eq('ns1.dnsimple.com admin.dnsimple.com 1458642070 86400 7200 604800 300');
         expect(records[0].ttl).to.eq(3600);
-        expect(records[0].priority).to.be.null;
+        expect(records[0].priority).to.eq(null);
         expect(records[0].type).to.eq('SOA');
-        expect(records[0].system_record).to.be.true;
+        expect(records[0].system_record).to.eq(true);
         expect(records[0].created_at).to.eq('2016-03-22T10:20:53Z');
         expect(records[0].updated_at).to.eq('2016-10-05T09:26:38Z');
         done();
@@ -89,7 +89,7 @@ describe('zone records', function () {
 
       dnsimple.zones.listZoneRecords(accountId, zoneId).then(function (response) {
         var pagination = response.pagination;
-        expect(pagination).to.not.be.null;
+        expect(pagination).to.not.eq(null);
         expect(pagination.current_page).to.eq(1);
         done();
       }, function (error) {
@@ -163,7 +163,7 @@ describe('zone records', function () {
         dnsimple.zones.getZoneRecord(accountId, zoneId, '0').then(function (response) {
           done('Error expected but future resolved');
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           expect(error.description).to.eq('Not found');
           expect(error.message).to.eq('Record `0` not found');
           done();
@@ -246,7 +246,7 @@ describe('zone records', function () {
         dnsimple.zones.updateZoneRecord(accountId, zoneId, recordId, attributes).then(function (response) {
           done();
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           done();
         });
       });
@@ -293,7 +293,7 @@ describe('zone records', function () {
         dnsimple.zones.deleteZoneRecord(accountId, zoneId, recordId).then(function (response) {
           done('Error expected but future resolved');
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           done();
         });
       });

--- a/test/dnsimple/zones.spec.js
+++ b/test/dnsimple/zones.spec.js
@@ -80,7 +80,7 @@ describe('zones', function () {
 
       dnsimple.zones.listZones(accountId).then(function (response) {
         var pagination = response.pagination;
-        expect(pagination).to.not.be.null;
+        expect(pagination).to.not.eq(null);
         expect(pagination.current_page).to.eq(1);
         done();
       }, function (error) {
@@ -135,7 +135,7 @@ describe('zones', function () {
         expect(zone.id).to.eq(1);
         expect(zone.account_id).to.eq(1010);
         expect(zone.name).to.eq('example-alpha.com');
-        expect(zone.reverse).to.be.false;
+        expect(zone.reverse).to.eq(false);
         expect(zone.created_at).to.eq('2015-04-23T07:40:03Z');
         expect(zone.updated_at).to.eq('2015-04-23T07:40:03Z');
         done();
@@ -154,7 +154,7 @@ describe('zones', function () {
         dnsimple.zones.getZone(accountId, 'example.com').then(function (response) {
           done();
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           expect(error.description).to.eq('Not found');
           expect(error.message).to.eq('Zone `0` not found');
           done();
@@ -174,7 +174,7 @@ describe('zones', function () {
 
       dnsimple.zones.getZoneFile(accountId, 'example-alpha.com').then(function (response) {
         var zone = response.data;
-        expect(zone).to.not.be.null;
+        expect(zone).to.not.eq(null);
         done();
       }, function (error) {
         done(error);
@@ -191,7 +191,7 @@ describe('zones', function () {
         dnsimple.zones.getZoneFile(accountId, 'example.com').then(function (response) {
           done();
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           done();
         });
       });
@@ -209,7 +209,7 @@ describe('zones', function () {
 
       dnsimple.zones.checkZoneDistribution(accountId, 'example-alpha.com').then(function (response) {
         var zone = response.data;
-        expect(zone).to.not.be.null;
+        expect(zone).to.not.eq(null);
         done();
       }, function (error) {
         done(error);
@@ -227,7 +227,7 @@ describe('zones', function () {
         dnsimple.zones.checkZoneDistribution(accountId, 'example.com').then(function (response) {
           done();
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           done();
         });
       });
@@ -244,7 +244,7 @@ describe('zones', function () {
         dnsimple.zones.checkZoneDistribution(accountId, 'example.com').then(function (response) {
           done();
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           done();
         });
       });
@@ -261,7 +261,7 @@ describe('zones', function () {
         dnsimple.zones.checkZoneDistribution(accountId, 'example.com').then(function (response) {
           done();
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           done();
         });
       });
@@ -280,7 +280,7 @@ describe('zones', function () {
 
       dnsimple.zones.checkZoneRecordDistribution(accountId, 'example-alpha.com', recordId).then(function (response) {
         var zone = response.data;
-        expect(zone).to.not.be.null;
+        expect(zone).to.not.eq(null);
         done();
       }, function (error) {
         done(error);
@@ -298,7 +298,7 @@ describe('zones', function () {
         dnsimple.zones.checkZoneRecordDistribution(accountId, 'example.com', recordId).then(function (response) {
           done();
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           done();
         });
       });
@@ -315,7 +315,7 @@ describe('zones', function () {
         dnsimple.zones.checkZoneRecordDistribution(accountId, 'example.com', recordId).then(function (response) {
           done();
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           done();
         });
       });
@@ -332,7 +332,7 @@ describe('zones', function () {
         dnsimple.zones.checkZoneRecordDistribution(accountId, 'example.com', recordId).then(function (response) {
           done();
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           done();
         });
       });
@@ -349,7 +349,7 @@ describe('zones', function () {
         dnsimple.zones.checkZoneRecordDistribution(accountId, 'example.com', recordId).then(function (response) {
           done();
         }, function (error) {
-          expect(error).to.not.be.null;
+          expect(error).to.not.eq(null);
           done();
         });
       });

--- a/test/dnsimple/zones.spec.js
+++ b/test/dnsimple/zones.spec.js
@@ -2,97 +2,97 @@
 
 var testUtils = require('../testUtils');
 var dnsimple = require('../../lib/dnsimple')({
-  accessToken: testUtils.getAccessToken(),
+  accessToken: testUtils.getAccessToken()
 });
 
 const expect = require('chai').expect;
 const nock = require('nock');
 
-describe('zones', function() {
-  describe('#listZones', function() {
+describe('zones', function () {
+  describe('#listZones', function () {
     var accountId = '1010';
     var fixture = testUtils.fixture('listZones/success.http');
 
-    it('supports pagination', function(done) {
+    it('supports pagination', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/zones?page=1')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.zones.listZones(accountId, {page: 1});
+      dnsimple.zones.listZones(accountId, { page: 1 });
 
       nock.isDone();
       done();
     });
 
-    it('supports extra request options', function(done) {
+    it('supports extra request options', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/zones?foo=bar')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.zones.listZones(accountId, {query: {foo: 'bar'}});
+      dnsimple.zones.listZones(accountId, { query: { foo: 'bar' } });
 
       nock.isDone();
       done();
     });
 
-    it('supports sorting', function(done) {
+    it('supports sorting', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/zones?sort=expires_on%3Aasc')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.zones.listZones(accountId, {sort: 'expires_on:asc'});
+      dnsimple.zones.listZones(accountId, { sort: 'expires_on:asc' });
 
       nock.isDone();
       done();
     });
 
-    it('supports filter', function(done) {
+    it('supports filter', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/zones?name_like=example')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.zones.listZones(accountId, {filter: {name_like: 'example'}});
+      dnsimple.zones.listZones(accountId, { filter: { name_like: 'example' } });
 
       nock.isDone();
       done();
     });
 
-    it('produces a zone list', function(done) {
+    it('produces a zone list', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/zones')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.zones.listZones(accountId).then(function(response) {
+      dnsimple.zones.listZones(accountId).then(function (response) {
         var zones = response.data;
         expect(zones.length).to.eq(2);
         expect(zones[0].name).to.eq('example-alpha.com');
         expect(zones[0].account_id).to.eq(1010);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    it('exposes the pagination info', function(done) {
+    it('exposes the pagination info', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/zones')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.zones.listZones(accountId).then(function(response) {
+      dnsimple.zones.listZones(accountId).then(function (response) {
         var pagination = response.pagination;
         expect(pagination).to.not.be.null;
         expect(pagination.current_page).to.eq(1);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
   });
 
-  describe('#allZones', function() {
+  describe('#allZones', function () {
     var accountId = '1010';
 
-    it('produces a complete list', function(done) {
+    it('produces a complete list', function (done) {
       var fixture1 = testUtils.fixture('pages-1of3.http');
       nock('https://api.dnsimple.com')
         .get('/v2/1010/zones?page=1')
@@ -108,29 +108,29 @@ describe('zones', function() {
         .get('/v2/1010/zones?page=3')
         .reply(fixture3.statusCode, fixture3.body);
 
-      dnsimple.zones.allZones(accountId).then(function(items) {
+      dnsimple.zones.allZones(accountId).then(function (items) {
         expect(items.length).to.eq(5);
         expect(items[0].id).to.eq(1);
         expect(items[4].id).to.eq(5);
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
-      }).catch(function(error) {
+      }).catch(function (error) {
         done(error);
       });
     });
   });
 
-  describe('#getZone', function() {
+  describe('#getZone', function () {
     var accountId = '1010';
     var fixture = testUtils.fixture('getZone/success.http');
 
-    it('produces a zone', function(done) {
+    it('produces a zone', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/zones/example-alpha.com')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.zones.getZone(accountId, 'example-alpha.com').then(function(response) {
+      dnsimple.zones.getZone(accountId, 'example-alpha.com').then(function (response) {
         var zone = response.data;
         expect(zone.id).to.eq(1);
         expect(zone.account_id).to.eq(1010);
@@ -139,21 +139,21 @@ describe('zones', function() {
         expect(zone.created_at).to.eq('2015-04-23T07:40:03Z');
         expect(zone.updated_at).to.eq('2015-04-23T07:40:03Z');
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    describe('when the zone does not exist', function() {
+    describe('when the zone does not exist', function () {
       var fixture = testUtils.fixture('notfound-zone.http');
       nock('https://api.dnsimple.com')
         .get('/v2/1010/zones/example.com')
         .reply(fixture.statusCode, fixture.body);
 
-      it('produces an error', function(done) {
-        dnsimple.zones.getZone(accountId, 'example.com').then(function(response) {
+      it('produces an error', function (done) {
+        dnsimple.zones.getZone(accountId, 'example.com').then(function (response) {
           done();
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           expect(error.description).to.eq('Not found');
           expect(error.message).to.eq('Zone `0` not found');
@@ -163,34 +163,34 @@ describe('zones', function() {
     });
   });
 
-  describe('#getZoneFile', function() {
+  describe('#getZoneFile', function () {
     var accountId = '1010';
     var fixture = testUtils.fixture('getZoneFile/success.http');
 
-    it('produces a zone file', function(done) {
+    it('produces a zone file', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/zones/example-alpha.com/file')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.zones.getZoneFile(accountId, 'example-alpha.com').then(function(response) {
+      dnsimple.zones.getZoneFile(accountId, 'example-alpha.com').then(function (response) {
         var zone = response.data;
         expect(zone).to.not.be.null;
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    describe('when the zone file does not exist', function() {
+    describe('when the zone file does not exist', function () {
       var fixture = testUtils.fixture('notfound-zone.http');
       nock('https://api.dnsimple.com')
         .get('/v2/1010/zones/example.com/file')
         .reply(fixture.statusCode, fixture.body);
 
-      it('produces an error', function(done) {
-        dnsimple.zones.getZoneFile(accountId, 'example.com').then(function(response) {
+      it('produces an error', function (done) {
+        dnsimple.zones.getZoneFile(accountId, 'example.com').then(function (response) {
           done();
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           done();
         });
@@ -198,69 +198,69 @@ describe('zones', function() {
     });
   });
 
-  describe('#checkZoneDistribution', function() {
+  describe('#checkZoneDistribution', function () {
     var accountId = '1010';
     var fixture = testUtils.fixture('checkZoneDistribution/success.http');
 
-    it('returns true when the zone is fully distributed', function(done) {
+    it('returns true when the zone is fully distributed', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/zones/example-alpha.com/distribution')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.zones.checkZoneDistribution(accountId, 'example-alpha.com').then(function(response) {
+      dnsimple.zones.checkZoneDistribution(accountId, 'example-alpha.com').then(function (response) {
         var zone = response.data;
         expect(zone).to.not.be.null;
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    describe('returns false when the zone is not fully distributed', function() {
+    describe('returns false when the zone is not fully distributed', function () {
       var fixture = testUtils.fixture('checkZoneDistribution/failure.http');
 
       nock('https://api.dnsimple.com')
         .get('/v2/1010/zones/example.com/distribution')
         .reply(fixture.statusCode, fixture.body);
 
-      it('produces an error', function(done) {
-        dnsimple.zones.checkZoneDistribution(accountId, 'example.com').then(function(response) {
+      it('produces an error', function (done) {
+        dnsimple.zones.checkZoneDistribution(accountId, 'example.com').then(function (response) {
           done();
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           done();
         });
       });
     });
 
-    describe('returns an error when the server was not able to complete the check', function() {
+    describe('returns an error when the server was not able to complete the check', function () {
       var fixture = testUtils.fixture('checkZoneDistribution/error.http');
 
       nock('https://api.dnsimple.com')
         .get('/v2/1010/zones/example.com/distribution')
         .reply(fixture.statusCode, fixture.body);
 
-      it('produces an error', function(done) {
-        dnsimple.zones.checkZoneDistribution(accountId, 'example.com').then(function(response) {
+      it('produces an error', function (done) {
+        dnsimple.zones.checkZoneDistribution(accountId, 'example.com').then(function (response) {
           done();
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           done();
         });
       });
     });
 
-    describe('when the zone does not exist', function() {
+    describe('when the zone does not exist', function () {
       var fixture = testUtils.fixture('notfound-zone.http');
 
       nock('https://api.dnsimple.com')
         .get('/v2/1010/zones/example.com/distribution')
         .reply(fixture.statusCode, fixture.body);
 
-      it('produces an error', function(done) {
-        dnsimple.zones.checkZoneDistribution(accountId, 'example.com').then(function(response) {
+      it('produces an error', function (done) {
+        dnsimple.zones.checkZoneDistribution(accountId, 'example.com').then(function (response) {
           done();
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           done();
         });
@@ -268,87 +268,87 @@ describe('zones', function() {
     });
   });
 
-  describe('#checkZoneRecordDistribution', function() {
+  describe('#checkZoneRecordDistribution', function () {
     var accountId = '1010';
     var recordId = 1;
     var fixture = testUtils.fixture('checkZoneRecordDistribution/success.http');
 
-    it('returns true when the zone record is fully distributed', function(done) {
+    it('returns true when the zone record is fully distributed', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/zones/example-alpha.com/records/1/distribution')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.zones.checkZoneRecordDistribution(accountId, 'example-alpha.com', recordId).then(function(response) {
+      dnsimple.zones.checkZoneRecordDistribution(accountId, 'example-alpha.com', recordId).then(function (response) {
         var zone = response.data;
         expect(zone).to.not.be.null;
         done();
-      }, function(error) {
+      }, function (error) {
         done(error);
       });
     });
 
-    describe('returns false when the zone record is not fully distributed', function() {
+    describe('returns false when the zone record is not fully distributed', function () {
       var fixture = testUtils.fixture('checkZoneRecordDistribution/failure.http');
 
       nock('https://api.dnsimple.com')
         .get('/v2/1010/zones/example.com/records/1/distribution')
         .reply(fixture.statusCode, fixture.body);
 
-      it('produces an error', function(done) {
-        dnsimple.zones.checkZoneRecordDistribution(accountId, 'example.com', recordId).then(function(response) {
+      it('produces an error', function (done) {
+        dnsimple.zones.checkZoneRecordDistribution(accountId, 'example.com', recordId).then(function (response) {
           done();
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           done();
         });
       });
     });
 
-    describe('returns an error when the server was not able to complete the check', function() {
+    describe('returns an error when the server was not able to complete the check', function () {
       var fixture = testUtils.fixture('checkZoneRecordDistribution/error.http');
 
       nock('https://api.dnsimple.com')
         .get('/v2/1010/zones/example.com/records/1/distribution')
         .reply(fixture.statusCode, fixture.body);
 
-      it('produces an error', function(done) {
-        dnsimple.zones.checkZoneRecordDistribution(accountId, 'example.com', recordId).then(function(response) {
+      it('produces an error', function (done) {
+        dnsimple.zones.checkZoneRecordDistribution(accountId, 'example.com', recordId).then(function (response) {
           done();
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           done();
         });
       });
     });
 
-    describe('when the zone does not exist', function() {
+    describe('when the zone does not exist', function () {
       var fixture = testUtils.fixture('notfound-zone.http');
 
       nock('https://api.dnsimple.com')
         .get('/v2/1010/zones/example.com/records/1/distribution')
         .reply(fixture.statusCode, fixture.body);
 
-      it('produces an error', function(done) {
-        dnsimple.zones.checkZoneRecordDistribution(accountId, 'example.com', recordId).then(function(response) {
+      it('produces an error', function (done) {
+        dnsimple.zones.checkZoneRecordDistribution(accountId, 'example.com', recordId).then(function (response) {
           done();
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           done();
         });
       });
     });
 
-    describe('when the zone record does not exist', function() {
+    describe('when the zone record does not exist', function () {
       var fixture = testUtils.fixture('notfound-record.http');
 
       nock('https://api.dnsimple.com')
         .get('/v2/1010/zones/example.com/records/1/distribution')
         .reply(fixture.statusCode, fixture.body);
 
-      it('produces an error', function(done) {
-        dnsimple.zones.checkZoneRecordDistribution(accountId, 'example.com', recordId).then(function(response) {
+      it('produces an error', function (done) {
+        dnsimple.zones.checkZoneRecordDistribution(accountId, 'example.com', recordId).then(function (response) {
           done();
-        }, function(error) {
+        }, function (error) {
           expect(error).to.not.be.null;
           done();
         });

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -5,7 +5,7 @@ require('chai').use(require('chai-as-promised'));
 
 const fs = require('fs');
 
-var utils = module.exports = {
+module.exports = {
 
   getAccessToken: function () {
     var key = process.env.TOKEN || 'bogus';
@@ -24,19 +24,21 @@ var utils = module.exports = {
 
     var headers = {};
     var val;
-    while ((val = lines.shift()) != '') {
+    while ((val = lines.shift()) !== '') {
       var pair = val.split(/:\s/);
       headers[pair[0]] = pair[1];
     }
 
     var fixture = {
+      httpVersion: httpVersion,
       statusCode: statusCode,
       headers: headers,
+      reasonPhrase: reasonPhrase,
       body: null
     };
 
-    if (statusCode != 204) {
-      if (headers['Content-Type'] == 'application/json') {
+    if (statusCode !== 204) {
+      if (headers['Content-Type'] === 'application/json') {
         fixture.body = JSON.parse(lines.join('\n'));
       } else {
         fixture.body = lines.join('\n');

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -7,13 +7,13 @@ const fs = require('fs');
 
 var utils = module.exports = {
 
-  getAccessToken: function() {
+  getAccessToken: function () {
     var key = process.env.TOKEN || 'bogus';
-    return key
+    return key;
   },
 
-  fixture: function(path) {
-    var data = fs.readFileSync('./test/fixtures.http/' + path, {encoding: 'UTF8'});
+  fixture: function (path) {
+    var data = fs.readFileSync('./test/fixtures.http/' + path, { encoding: 'UTF8' });
     var lines = data.split(/\r?\n/);
 
     var statusLine = lines.shift();
@@ -32,8 +32,8 @@ var utils = module.exports = {
     var fixture = {
       statusCode: statusCode,
       headers: headers,
-      body: null,
-    }
+      body: null
+    };
 
     if (statusCode != 204) {
       if (headers['Content-Type'] == 'application/json') {
@@ -44,6 +44,6 @@ var utils = module.exports = {
     }
 
     return fixture;
-  },
+  }
 
-}
+};


### PR DESCRIPTION
Fixes https://github.com/dnsimple/dnsimple-node/issues/28

This PR: 

- Implements https://www.npmjs.com/package/semistandard (chosen it over https://www.npmjs.com/package/standard since I like semicolons, and our current code base was already formatted that way)
- Fixes several warnings and recommendations (check commits messages)
- Drops support for NodeJS v8 (as it was deprecated on 2019-12-31)

⚠️  As we are dropping NodeJS v8 support, we should relese this as a major release