### PR TITLE
Implement client methods for Transfer API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## master
 
 - NEW: Adds NodeJS v14 to Travis build
+- NEW: Added `registrar.getDomainTransfer` to retrieve a domain transfer. (dnsimple/dnsimple-node#40)
+- NEW: Added `registrar.cancelDomainTransfer` to cancel an in progress domain transfer. (dnsimple/dnsimple-node#40)
 
 ## Release 4.0.0
 

--- a/lib/dnsimple/registrar.js
+++ b/lib/dnsimple/registrar.js
@@ -130,6 +130,50 @@ class Registrar {
   }
 
   /**
+   * Retrieves the details of an existing domain transfer.
+   *
+   * @see https://developer.dnsimple.com/v2/registrar/#getDomainTransfer
+   *
+   * @example Retrieve the transfer 42 for example.com
+   * client.registrar.getDomainTransfer(1010, 'example.com', 42).then(function(response) {
+   *  // handle response
+   * }, function(error) {
+   *  // handle error
+   * });
+   *
+   * @param {number} accountId The account ID
+   * @param {string} domainName The domain name to transfer
+   * @param {number} domainTransferId The domain transfer ID
+   * @param {Object} [options]
+   * @return {Promise}
+   */
+  getDomainTransfer (accountId, domainName, domainTransferId, options = {}) {
+    return this._client.get(this._registrarPath(accountId, domainName, `transfers/${domainTransferId}`), options);
+  }
+
+  /**
+   * Cancels an in progress domain transfer.
+   *
+   * @see https://developer.dnsimple.com/v2/registrar/#cancelDomainTransfer
+   *
+   * @example Cancel the transfer 42 for example.com
+   * client.registrar.cancelDomainTransfer(1010, 'example.com', 42).then(function(response) {
+   *  // handle response
+   * }, function(error) {
+   *  // handle error
+   * });
+   *
+   * @param {number} accountId The account ID
+   * @param {string} domainName The domain name to transfer
+   * @param {number} domainTransferId The domain transfer ID
+   * @param {Object} [options]
+   * @return {Promise}
+   */
+  cancelDomainTransfer (accountId, domainName, domainTransferId, options = {}) {
+    return this._client.delete(this._registrarPath(accountId, domainName, `transfers/${domainTransferId}`), options);
+  }
+
+  /**
    * Requests the transfer of a domain out of DNSimple.
    *
    * @see https://developer.dnsimple.com/v2/registrar/#transfer-out

--- a/test/dnsimple/registrar.spec.js
+++ b/test/dnsimple/registrar.spec.js
@@ -192,6 +192,58 @@ describe('registrar', function () {
     });
   });
 
+  describe('#getDomainTransfer', function () {
+    var fixture = testUtils.fixture('getDomainTransfer/success.http');
+
+    it('produces a domain transfer', function (done) {
+      nock('https://api.dnsimple.com')
+        .get('/v2/1010/registrar/domains/example.com/transfers/42')
+        .reply(fixture.statusCode, fixture.body);
+
+      dnsimple.registrar.getDomainTransfer(accountId, domainId, 42).then(function (response) {
+        var domainTransfer = response.data;
+        expect(domainTransfer.id).to.eq(42);
+        expect(domainTransfer.domain_id).to.eq(2);
+        expect(domainTransfer.registrant_id).to.eq(3);
+        expect(domainTransfer.state).to.eq('cancelled');
+        expect(domainTransfer.auto_renew).to.eq(false);
+        expect(domainTransfer.whois_privacy).to.eq(false);
+        expect(domainTransfer.status_description).to.eq('Canceled by customer');
+        expect(domainTransfer.created_at).to.eq('2020-04-27T18:08:44Z');
+        expect(domainTransfer.updated_at).to.eq('2020-04-27T18:20:01Z');
+        done();
+      }, function (error) {
+        done(error);
+      });
+    });
+  });
+
+  describe('#cancelDomainTransfer', function () {
+    var fixture = testUtils.fixture('cancelDomainTransfer/success.http');
+
+    it('produces a domain transfer', function (done) {
+      nock('https://api.dnsimple.com')
+        .delete('/v2/1010/registrar/domains/example.com/transfers/42')
+        .reply(fixture.statusCode, fixture.body);
+
+      dnsimple.registrar.cancelDomainTransfer(accountId, domainId, 42).then(function (response) {
+        var domainTransfer = response.data;
+        expect(domainTransfer.id).to.eq(42);
+        expect(domainTransfer.domain_id).to.eq(6);
+        expect(domainTransfer.registrant_id).to.eq(1);
+        expect(domainTransfer.state).to.eq('transferring');
+        expect(domainTransfer.auto_renew).to.eq(true);
+        expect(domainTransfer.whois_privacy).to.eq(false);
+        expect(domainTransfer.status_description).to.eq(null);
+        expect(domainTransfer.created_at).to.eq('2020-04-24T19:19:03Z');
+        expect(domainTransfer.updated_at).to.eq('2020-04-24T19:19:15Z');
+        done();
+      }, function (error) {
+        done(error);
+      });
+    });
+  });
+
   describe('#transferDomainOut', function () {
     var fixture = testUtils.fixture('authorizeDomainTransferOut/success.http');
 

--- a/test/dnsimple/registrar.spec.js
+++ b/test/dnsimple/registrar.spec.js
@@ -195,7 +195,7 @@ describe('registrar', function () {
   describe('#getDomainTransfer', function () {
     var fixture = testUtils.fixture('getDomainTransfer/success.http');
 
-    it('produces a domain transfer', function (done) {
+    it('retrieves a domain transfer', function (done) {
       nock('https://api.dnsimple.com')
         .get('/v2/1010/registrar/domains/example.com/transfers/42')
         .reply(fixture.statusCode, fixture.body);
@@ -221,7 +221,7 @@ describe('registrar', function () {
   describe('#cancelDomainTransfer', function () {
     var fixture = testUtils.fixture('cancelDomainTransfer/success.http');
 
-    it('produces a domain transfer', function (done) {
+    it('cancels a domain transfer', function (done) {
       nock('https://api.dnsimple.com')
         .delete('/v2/1010/registrar/domains/example.com/transfers/42')
         .reply(fixture.statusCode, fixture.body);

--- a/test/fixtures.http/cancelDomainTransfer/success.http
+++ b/test/fixtures.http/cancelDomainTransfer/success.http
@@ -1,0 +1,30 @@
+HTTP/1.1 202 Accepted
+Server: nginx
+Date: Wed, 29 Apr 2020 19:49:41 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 202 Accepted
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2397
+X-RateLimit-Reset: 1588193270
+ETag: W/"8404bf2739e44e9f69f3a5199466776d"
+Cache-Control: no-store, must-revalidate, private, max-age=0
+X-Request-Id: 10d75bcf-0066-4d38-98a2-dc18dd5b6f4c
+X-Runtime: 1.752154
+Strict-Transport-Security: max-age=31536000
+
+{
+  "data": {
+    "id": 42,
+    "domain_id": 6,
+    "registrant_id": 1,
+    "state": "transferring",
+    "auto_renew": true,
+    "whois_privacy": false,
+    "premium_price": null,
+    "status_description": null,
+    "created_at": "2020-04-24T19:19:03Z",
+    "updated_at": "2020-04-24T19:19:15Z"
+  }
+}

--- a/test/fixtures.http/getDomainTransfer/success.http
+++ b/test/fixtures.http/getDomainTransfer/success.http
@@ -1,0 +1,30 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Mon, 27 Apr 2020 19:40:00 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 200 OK
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2398
+X-RateLimit-Reset: 1588019949
+ETag: W/"8404bf2739e44e9f69f3a5199466776d"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 4818d867-1f72-4619-ab46-d345e6dd25eb
+X-Runtime: 0.092854
+Strict-Transport-Security: max-age=31536000
+
+{
+  "data": {
+    "id": 42,
+    "domain_id": 2,
+    "registrant_id": 3,
+    "state": "cancelled",
+    "auto_renew": false,
+    "whois_privacy": false,
+    "premium_price": null,
+    "status_description": "Canceled by customer",
+    "created_at": "2020-04-27T18:08:44Z",
+    "updated_at": "2020-04-27T18:20:01Z"
+  }
+}


### PR DESCRIPTION
This commit introduces two client methods for the new features in
TransferAPI:
- getDomainTransfer - Retrieves the information for a specific domain
transfer
- cancelDomainTransfer - Cancels an in progress domain transfer