### PR TITLE
Introduce expires_at for Domain and update fixtures

### DIFF
--- a/test/dnsimple/domains.spec.js
+++ b/test/dnsimple/domains.spec.js
@@ -37,10 +37,10 @@ describe('domains', function () {
 
     it('supports sorting', function (done) {
       nock('https://api.dnsimple.com')
-        .get('/v2/1010/domains?sort=expires_on%3Aasc')
+        .get('/v2/1010/domains?sort=expiration%3Aasc')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.domains.listDomains(accountId, { sort: 'expires_on:asc' });
+      dnsimple.domains.listDomains(accountId, { sort: 'expiration:asc' });
 
       nock.isDone();
       done();
@@ -66,7 +66,7 @@ describe('domains', function () {
         var domains = response.data;
         expect(domains.length).to.eq(2);
         expect(domains[0].name).to.eq('example-alpha.com');
-        expect(domains[0].account_id).to.eq(1010);
+        expect(domains[0].account_id).to.eq(1385);
         done();
       }, function (error) {
         done(error);
@@ -122,27 +122,28 @@ describe('domains', function () {
   });
 
   describe('#getDomain', function () {
-    var accountId = '1010';
+    var accountId = '1385';
     var domainId = 'example-alpha.com';
     var fixture = testUtils.fixture('getDomain/success.http');
 
     it('produces a domain', function (done) {
       nock('https://api.dnsimple.com')
-        .get('/v2/1010/domains/example-alpha.com')
+        .get('/v2/1385/domains/example-alpha.com')
         .reply(fixture.statusCode, fixture.body);
 
       dnsimple.domains.getDomain(accountId, domainId).then(function (response) {
         var domain = response.data;
-        expect(domain.id).to.eq(1);
-        expect(domain.account_id).to.eq(1010);
-        expect(domain.registrant_id).to.eq(null);
+        expect(domain.id).to.eq(181984);
+        expect(domain.account_id).to.eq(1385);
+        expect(domain.registrant_id).to.eq(2715);
         expect(domain.name).to.eq('example-alpha.com');
-        expect(domain.state).to.eq('hosted');
+        expect(domain.state).to.eq('registered');
         expect(domain.auto_renew).to.eq(false);
         expect(domain.private_whois).to.eq(false);
-        expect(domain.expires_on).to.eq(null);
-        expect(domain.created_at).to.eq('2014-12-06T15:56:55Z');
-        expect(domain.updated_at).to.eq('2015-12-09T00:20:56Z');
+        expect(domain.expires_on).to.eq('2021-06-05');
+        expect(domain.expires_at).to.eq('2021-06-05T02:15:00Z');
+        expect(domain.created_at).to.eq('2020-06-04T19:15:14Z');
+        expect(domain.updated_at).to.eq('2020-06-04T19:15:21Z');
         done();
       }, function (error) {
         done(error);
@@ -152,7 +153,7 @@ describe('domains', function () {
     describe('when the domain does not exist', function () {
       var fixture = testUtils.fixture('notfound-domain.http');
       nock('https://api.dnsimple.com')
-        .get('/v2/1010/domains/0')
+        .get('/v2/1385/domains/0')
         .reply(fixture.statusCode, fixture.body);
 
       it('produces an error', function (done) {
@@ -169,13 +170,13 @@ describe('domains', function () {
   });
 
   describe('#createDomain', function () {
-    var accountId = '1010';
+    var accountId = '1385';
     var attributes = { name: 'example-alpha.com' };
     var fixture = testUtils.fixture('createDomain/created.http');
 
     it('builds the correct request', function (done) {
       nock('https://api.dnsimple.com')
-        .post('/v2/1010/domains', attributes)
+        .post('/v2/1385/domains', attributes)
         .reply(fixture.statusCode, fixture.body);
 
       dnsimple.domains.createDomain(accountId, attributes);
@@ -186,12 +187,12 @@ describe('domains', function () {
 
     it('produces a domain', function (done) {
       nock('https://api.dnsimple.com')
-        .post('/v2/1010/domains')
+        .post('/v2/1385/domains')
         .reply(fixture.statusCode, fixture.body);
 
       dnsimple.domains.createDomain(accountId, attributes).then(function (response) {
         var domain = response.data;
-        expect(domain.id).to.eq(1);
+        expect(domain.id).to.eq(181985);
         done();
       }, function (error) {
         done(error);

--- a/test/dnsimple/registrar.spec.js
+++ b/test/dnsimple/registrar.spec.js
@@ -202,15 +202,15 @@ describe('registrar', function () {
 
       dnsimple.registrar.getDomainTransfer(accountId, domainId, 42).then(function (response) {
         var domainTransfer = response.data;
-        expect(domainTransfer.id).to.eq(42);
-        expect(domainTransfer.domain_id).to.eq(2);
-        expect(domainTransfer.registrant_id).to.eq(3);
+        expect(domainTransfer.id).to.eq(361);
+        expect(domainTransfer.domain_id).to.eq(182245);
+        expect(domainTransfer.registrant_id).to.eq(2715);
         expect(domainTransfer.state).to.eq('cancelled');
         expect(domainTransfer.auto_renew).to.eq(false);
         expect(domainTransfer.whois_privacy).to.eq(false);
         expect(domainTransfer.status_description).to.eq('Canceled by customer');
-        expect(domainTransfer.created_at).to.eq('2020-04-27T18:08:44Z');
-        expect(domainTransfer.updated_at).to.eq('2020-04-27T18:20:01Z');
+        expect(domainTransfer.created_at).to.eq('2020-06-05T18:08:00Z');
+        expect(domainTransfer.updated_at).to.eq('2020-06-05T18:10:01Z');
         done();
       }, function (error) {
         done(error);
@@ -228,15 +228,15 @@ describe('registrar', function () {
 
       dnsimple.registrar.cancelDomainTransfer(accountId, domainId, 42).then(function (response) {
         var domainTransfer = response.data;
-        expect(domainTransfer.id).to.eq(42);
-        expect(domainTransfer.domain_id).to.eq(6);
-        expect(domainTransfer.registrant_id).to.eq(1);
+        expect(domainTransfer.id).to.eq(361);
+        expect(domainTransfer.domain_id).to.eq(182245);
+        expect(domainTransfer.registrant_id).to.eq(2715);
         expect(domainTransfer.state).to.eq('transferring');
-        expect(domainTransfer.auto_renew).to.eq(true);
+        expect(domainTransfer.auto_renew).to.eq(false);
         expect(domainTransfer.whois_privacy).to.eq(false);
         expect(domainTransfer.status_description).to.eq(null);
-        expect(domainTransfer.created_at).to.eq('2020-04-24T19:19:03Z');
-        expect(domainTransfer.updated_at).to.eq('2020-04-24T19:19:15Z');
+        expect(domainTransfer.created_at).to.eq('2020-06-05T18:08:00Z');
+        expect(domainTransfer.updated_at).to.eq('2020-06-05T18:08:04Z');
         done();
       }, function (error) {
         done(error);

--- a/test/dnsimple/webhooks.spec.js
+++ b/test/dnsimple/webhooks.spec.js
@@ -11,7 +11,7 @@ const nock = require('nock');
 describe('webhooks', function () {
   describe('#listWebhooks', function () {
     var accountId = '1010';
-    var fixture = testUtils.fixture('listDomains/success.http');
+    var fixture = testUtils.fixture('listWebhooks/success.http');
 
     it('supports extra request options', function (done) {
       nock('https://api.dnsimple.com')
@@ -42,7 +42,7 @@ describe('webhooks', function () {
 
   describe('#allWebhooks', function () {
     var accountId = '1010';
-    var fixture = testUtils.fixture('listDomains/success.http');
+    var fixture = testUtils.fixture('listWebhooks/success.http');
 
     it('supports extra request options', function (done) {
       nock('https://api.dnsimple.com')

--- a/test/fixtures.http/cancelDomainTransfer/success.http
+++ b/test/fixtures.http/cancelDomainTransfer/success.http
@@ -1,30 +1,19 @@
 HTTP/1.1 202 Accepted
 Server: nginx
-Date: Wed, 29 Apr 2020 19:49:41 GMT
+Date: Fri, 05 Jun 2020 18:09:42 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
-Status: 202 Accepted
 X-RateLimit-Limit: 2400
-X-RateLimit-Remaining: 2397
-X-RateLimit-Reset: 1588193270
-ETag: W/"8404bf2739e44e9f69f3a5199466776d"
-Cache-Control: no-store, must-revalidate, private, max-age=0
-X-Request-Id: 10d75bcf-0066-4d38-98a2-dc18dd5b6f4c
-X-Runtime: 1.752154
-Strict-Transport-Security: max-age=31536000
+X-RateLimit-Remaining: 2394
+X-RateLimit-Reset: 1591384034
+Cache-Control: no-cache
+X-Request-Id: 3cf6dcfa-0bb5-439e-863a-af2ef08bc830
+X-Runtime: 0.912731
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
 
-{
-  "data": {
-    "id": 42,
-    "domain_id": 6,
-    "registrant_id": 1,
-    "state": "transferring",
-    "auto_renew": true,
-    "whois_privacy": false,
-    "premium_price": null,
-    "status_description": null,
-    "created_at": "2020-04-24T19:19:03Z",
-    "updated_at": "2020-04-24T19:19:15Z"
-  }
-}
+{"data":{"id":361,"domain_id":182245,"registrant_id":2715,"state":"transferring","auto_renew":false,"whois_privacy":false,"status_description":null,"created_at":"2020-06-05T18:08:00Z","updated_at":"2020-06-05T18:08:04Z"}}

--- a/test/fixtures.http/createDomain/created.http
+++ b/test/fixtures.http/createDomain/created.http
@@ -1,16 +1,21 @@
 HTTP/1.1 201 Created
 Server: nginx
-Date: Fri, 18 Dec 2015 16:38:07 GMT
+Date: Thu, 04 Jun 2020 19:47:05 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
-X-RateLimit-Limit: 4000
-X-RateLimit-Remaining: 3986
-X-RateLimit-Reset: 1450456686
-ETag: W/"87e018b900e5f210c3236f63d3b2f4df"
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2378
+X-RateLimit-Reset: 1591300248
+ETag: W/"399e70627412fa31dba332feca5e8ec1"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: 0d6f1ea7-f702-4317-85f0-04874b69315d
-X-Runtime: 0.257489
+X-Request-Id: ee897eee-36cc-4b7f-be15-f4627f344bf9
+X-Runtime: 0.194561
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"account_id":1010,"registrant_id":null,"name":"example-alpha.com","unicode_name":"example-alpha.com","token":"domain-token","state":"hosted","auto_renew":false,"private_whois":false,"expires_on":null,"created_at":"2014-12-06T15:56:55Z","updated_at":"2015-12-09T00:20:56Z"}}
+{"data":{"id":181985,"account_id":1385,"registrant_id":null,"name":"example-beta.com","unicode_name":"example-beta.com","state":"hosted","auto_renew":false,"private_whois":false,"expires_on":null,"expires_at":null,"created_at":"2020-06-04T19:47:05Z","updated_at":"2020-06-04T19:47:05Z"}}

--- a/test/fixtures.http/getDomain/success.http
+++ b/test/fixtures.http/getDomain/success.http
@@ -1,16 +1,21 @@
 HTTP/1.1 200 OK
 Server: nginx
-Date: Wed, 16 Dec 2015 21:54:55 GMT
+Date: Thu, 04 Jun 2020 19:37:22 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
-X-RateLimit-Limit: 4000
-X-RateLimit-Remaining: 3993
-X-RateLimit-Reset: 1450302894
-ETag: W/"e7282090a87379d1fa3507ba6bfd1721"
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2379
+X-RateLimit-Reset: 1591300247
+ETag: W/"ff4a8463ecca39d4869695d66de60043"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: 3d8da18a-b8b2-4bfd-827c-860da837c80f
-X-Runtime: 0.020346
+X-Request-Id: 2e8259ab-c933-487e-8f85-d23f1cdf62fa
+X-Runtime: 0.019482
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"account_id":1010,"registrant_id":null,"name":"example-alpha.com","unicode_name":"example-alpha.com","token":"domain-token","state":"hosted","auto_renew":false,"private_whois":false,"expires_on":null,"created_at":"2014-12-06T15:56:55Z","updated_at":"2015-12-09T00:20:56Z"}}
+{"data":{"id":181984,"account_id":1385,"registrant_id":2715,"name":"example-alpha.com","unicode_name":"example-alpha.com","state":"registered","auto_renew":false,"private_whois":false,"expires_on":"2021-06-05","expires_at":"2021-06-05T02:15:00Z","created_at":"2020-06-04T19:15:14Z","updated_at":"2020-06-04T19:15:21Z"}}

--- a/test/fixtures.http/getDomainTransfer/success.http
+++ b/test/fixtures.http/getDomainTransfer/success.http
@@ -1,30 +1,21 @@
 HTTP/1.1 200 OK
 Server: nginx
-Date: Mon, 27 Apr 2020 19:40:00 GMT
+Date: Fri, 05 Jun 2020 18:23:53 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
-Status: 200 OK
 X-RateLimit-Limit: 2400
-X-RateLimit-Remaining: 2398
-X-RateLimit-Reset: 1588019949
-ETag: W/"8404bf2739e44e9f69f3a5199466776d"
+X-RateLimit-Remaining: 2392
+X-RateLimit-Reset: 1591384034
+ETag: W/"80c5827934c13b1ca87a587d96e7d1e8"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: 4818d867-1f72-4619-ab46-d345e6dd25eb
-X-Runtime: 0.092854
+X-Request-Id: 9f4959ee-06a9-488c-906e-27a570cafbbf
+X-Runtime: 0.078429
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
 Strict-Transport-Security: max-age=31536000
 
-{
-  "data": {
-    "id": 42,
-    "domain_id": 2,
-    "registrant_id": 3,
-    "state": "cancelled",
-    "auto_renew": false,
-    "whois_privacy": false,
-    "premium_price": null,
-    "status_description": "Canceled by customer",
-    "created_at": "2020-04-27T18:08:44Z",
-    "updated_at": "2020-04-27T18:20:01Z"
-  }
-}
+{"data":{"id":361,"domain_id":182245,"registrant_id":2715,"state":"cancelled","auto_renew":false,"whois_privacy":false,"status_description":"Canceled by customer","created_at":"2020-06-05T18:08:00Z","updated_at":"2020-06-05T18:10:01Z"}}

--- a/test/fixtures.http/listDomains/success.http
+++ b/test/fixtures.http/listDomains/success.http
@@ -1,16 +1,21 @@
 HTTP/1.1 200 OK
 Server: nginx
-Date: Wed, 16 Dec 2015 13:36:11 GMT
+Date: Thu, 04 Jun 2020 19:54:16 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
-X-RateLimit-Limit: 4000
-X-RateLimit-Remaining: 3997
-X-RateLimit-Reset: 1450272970
-ETag: W/"2679531e6cce6cd326f255255d7a0005"
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2399
+X-RateLimit-Reset: 1591304056
+ETag: W/"732eac2d85c19810f4e84dbc0eaafb9d"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: a87f1b44-150a-4ed0-b7da-9301fa1465b0
-X-Runtime: 0.093714
+X-Request-Id: 458d7b96-bb1a-469a-817e-4fd65c0f1db3
+X-Runtime: 0.125593
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
 Strict-Transport-Security: max-age=31536000
 
-{"data":[{"id":1,"account_id":1010,"registrant_id":null,"name":"example-alpha.com","unicode_name":"example-alpha.com","token":"domain-token","state":"hosted","auto_renew":false,"private_whois":false,"expires_on":null,"created_at":"2014-12-06T15:56:55Z","updated_at":"2015-12-09T00:20:56Z"},{"id":2,"account_id":1010,"registrant_id":21,"name":"example-beta.com","unicode_name":"example-beta.com","token":"domain-token","state":"registered","auto_renew":false,"private_whois":false,"expires_on":"2015-12-06","created_at":"2014-12-06T15:46:52Z","updated_at":"2015-12-09T00:20:53Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}
+{"data":[{"id":181984,"account_id":1385,"registrant_id":2715,"name":"example-alpha.com","unicode_name":"example-alpha.com","state":"registered","auto_renew":false,"private_whois":false,"expires_on":"2021-06-05","expires_at":"2021-06-05T02:15:00Z","created_at":"2020-06-04T19:15:14Z","updated_at":"2020-06-04T19:15:21Z"},{"id":181985,"account_id":1385,"registrant_id":null,"name":"example-beta.com","unicode_name":"example-beta.com","state":"hosted","auto_renew":false,"private_whois":false,"expires_on":null,"expires_at":null,"created_at":"2020-06-04T19:47:05Z","updated_at":"2020-06-04T19:47:05Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}

--- a/test/fixtures.http/registerDomain/success.http
+++ b/test/fixtures.http/registerDomain/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Fri, 09 Dec 2016 19:35:38 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2396
@@ -18,4 +18,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"domain_id":999,"registrant_id":2,"period":1,"state":"new","auto_renew":false,"whois_privacy":false,"premium_price":null,"created_at":"2016-12-09T19:35:31Z","updated_at":"2016-12-09T19:35:31Z"}}
+{"data":{"id":1,"domain_id":999,"registrant_id":2,"period":1,"state":"new","auto_renew":false,"whois_privacy":false,"created_at":"2016-12-09T19:35:31Z","updated_at":"2016-12-09T19:35:31Z"}}

--- a/test/fixtures.http/renewDomain/success.http
+++ b/test/fixtures.http/renewDomain/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Fri, 09 Dec 2016 19:46:57 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2394
@@ -18,4 +18,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"domain_id":999,"period":1,"state":"new","premium_price":null,"created_at":"2016-12-09T19:46:45Z","updated_at":"2016-12-09T19:46:45Z"}}
+{"data":{"id":1,"domain_id":999,"period":1,"state":"new","created_at":"2016-12-09T19:46:45Z","updated_at":"2016-12-09T19:46:45Z"}}

--- a/test/fixtures.http/transferDomain/success.http
+++ b/test/fixtures.http/transferDomain/success.http
@@ -2,7 +2,7 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Fri, 09 Dec 2016 19:43:43 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2395
@@ -18,4 +18,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"domain_id":999,"registrant_id":2,"state":"transferring","auto_renew":false,"whois_privacy":false,"premium_price":null,"created_at":"2016-12-09T19:43:41Z","updated_at":"2016-12-09T19:43:43Z"}}
+{"data":{"id":1,"domain_id":999,"registrant_id":2,"state":"transferring","auto_renew":false,"whois_privacy":false,"created_at":"2016-12-09T19:43:41Z","updated_at":"2016-12-09T19:43:43Z"}}


### PR DESCRIPTION
We deprecated expires_on attribute in our app and docs in favor of
expires_at. This commit introduces the new field in Domain response and
also updates fixtures with the new expires_at and the one that removed 
premium_price.