### PR TITLE
Introduce expires_at for Certificate and update fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - CHANGED: Bump mocha from 7.1.2 to 7.2.0
 - CHANGED: Bump js-yaml from 3.13.1 to 3.14.0
+- CHANGED: Domain object deprecates `expires_on` attribute in favor of `expires_at`. (dnsimple/dnsimple-node#43)
+- CHANGED: Certificate object deprecates `expires_on` attribute in favor of `expires_at`. (dnsimple/dnsimple-node#45)
 
 ## Release 4.1.0
 

--- a/test/dnsimple/certificates.spec.js
+++ b/test/dnsimple/certificates.spec.js
@@ -55,9 +55,9 @@ describe('certificates', function () {
       dnsimple.certificates.listCertificates(accountId, domainId).then(function (response) {
         var certificates = response.data;
         expect(certificates.length).to.eq(2);
-        expect(certificates[0].id).to.eq(1);
-        expect(certificates[0].domain_id).to.eq(10);
-        expect(certificates[0].common_name).to.eq('www.weppos.net');
+        expect(certificates[0].id).to.eq(101973);
+        expect(certificates[0].domain_id).to.eq(14279);
+        expect(certificates[0].common_name).to.eq('www2.dnsimple.us');
         done();
       }, function (error) {
         done(error);
@@ -126,13 +126,13 @@ describe('certificates', function () {
 
       dnsimple.certificates.getCertificate(accountId, domainId, certificateId).then(function (response) {
         var certificate = response.data;
-        expect(certificate.id).to.eq(1);
-        expect(certificate.domain_id).to.eq(2);
-        expect(certificate.contact_id).to.eq(3);
-        expect(certificate.common_name).to.eq('www.weppos.net');
-        expect(certificate.alternate_names).to.eql(['weppos.net', 'www.weppos.net']);
+        expect(certificate.id).to.eq(101967);
+        expect(certificate.domain_id).to.eq(289333);
+        expect(certificate.contact_id).to.eq(2511);
+        expect(certificate.common_name).to.eq('www.bingo.pizza');
+        expect(certificate.alternate_names).to.eql([]);
         expect(certificate.state).to.eq('issued');
-        expect(certificate.expires_on).to.eq('2016-09-09');
+        expect(certificate.expires_on).to.eq('2020-09-16');
         done();
       }, function (error) {
         done(error);
@@ -248,7 +248,7 @@ describe('certificates', function () {
 
       dnsimple.certificates.purchaseLetsencryptCertificate(accountId, domainId, attributes).then(function (response) {
         var certificate = response.data;
-        expect(certificate.id).to.eq(300);
+        expect(certificate.id).to.eq(101967);
         done();
       }, function (error) {
         done(error);
@@ -259,7 +259,7 @@ describe('certificates', function () {
   describe('#issueLetsencryptCertificate', function () {
     var accountId = '1010';
     var domainId = 'example.com';
-    var certificateId = 200;
+    var certificateId = 101967;
     var fixture = testUtils.fixture('issueLetsencryptCertificate/success.http');
 
     it('issues a certificate', function (done) {
@@ -280,7 +280,7 @@ describe('certificates', function () {
   describe('#purchaseLetsencryptCertificateRenewal', function () {
     var accountId = '1010';
     var domainId = 'example.com';
-    var certificateId = 200;
+    var certificateId = 101967;
     var fixture = testUtils.fixture('purchaseRenewalLetsencryptCertificate/success.http');
 
     it('purchases a certificate renewal', function (done) {
@@ -291,9 +291,9 @@ describe('certificates', function () {
       dnsimple.certificates.purchaseLetsencryptCertificateRenewal(accountId, domainId, certificateId)
         .then(function (response) {
           var certificateRenewal = response.data;
-          expect(certificateRenewal.id).to.eq(999);
+          expect(certificateRenewal.id).to.eq(65082);
           expect(certificateRenewal.old_certificate_id).to.eq(certificateId);
-          expect(certificateRenewal.new_certificate_id).to.eq(300);
+          expect(certificateRenewal.new_certificate_id).to.eq(101972);
           done();
         }, function (error) {
           done(error);
@@ -304,8 +304,9 @@ describe('certificates', function () {
   describe('#issueLetsencryptCertificateRenewal', function () {
     var accountId = '1010';
     var domainId = 'example.com';
-    var certificateId = 200;
-    var certificateRenewalId = 999;
+    var certificateId = 101967;
+    var certificateRenewalId = 65082;
+    var newCertificateId = 101972;
     var fixture = testUtils.fixture('issueRenewalLetsencryptCertificate/success.http');
 
     it('issues a certificate renewal', function (done) {
@@ -315,8 +316,8 @@ describe('certificates', function () {
 
       dnsimple.certificates.issueLetsencryptCertificateRenewal(accountId, domainId, certificateId, certificateRenewalId)
         .then(function (response) {
-          var certificateRenewal = response.data;
-          expect(certificateRenewal.id).to.eq(certificateRenewalId);
+          var newCertificate = response.data;
+          expect(newCertificate.id).to.eq(newCertificateId);
           done();
         }, function (error) {
           done(error);

--- a/test/fixtures.http/getCertificate/success.http
+++ b/test/fixtures.http/getCertificate/success.http
@@ -1,21 +1,21 @@
 HTTP/1.1 200 OK
 Server: nginx
-Date: Fri, 08 Jul 2016 15:38:13 GMT
+Date: Thu, 18 Jun 2020 19:16:29 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
-X-RateLimit-Limit: 2400
-X-RateLimit-Remaining: 2396
-X-RateLimit-Reset: 1467993483
-ETag: W/"cf565290606493623c2dd9fee039b9f1"
+X-RateLimit-Limit: 4800
+X-RateLimit-Remaining: 4797
+X-RateLimit-Reset: 1592510057
+ETag: W/"9ace4f536d7b618fd4b38efd3cea9d1f"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: b6d5717d-d660-41dd-996c-4cc151d1f872
-X-Runtime: 0.037324
-X-Content-Type-Options: nosniff
-X-Download-Options: noopen
+X-Request-Id: 83905116-1333-4b07-ace4-d0db9e90c4fa
+X-Runtime: 0.012798
 X-Frame-Options: DENY
-X-Permitted-Cross-Domain-Policies: none
+X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"domain_id":2,"contact_id":3,"name":"www","common_name":"www.weppos.net","years":1,"csr":"-----BEGIN CERTIFICATE REQUEST-----\nMIICljCCAX4CAQAwGTEXMBUGA1UEAwwOd3d3LndlcHBvcy5uZXQwggEiMA0GCSqG\nSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC3MJwx9ahBG3kAwRjQdRvYZqtovUaxY6jp\nhd09975gO+2eYPDbc1yhNftVJ4KBT0zdEqzX0CwIlxE1MsnZ2YOsC7IJO531hMBp\ndBxM4tSG07xPz70AVUi9rY6YCUoJHmxoFbclpHFbtXZocR393WyzUK8047uM2mlz\n03AZKcMdyfeuo2/9TcxpTSCkklGqwqS9wtTogckaDHJDoBunAkMioGfOSMe7Yi6E\nYRtG4yPJYsDaq2yPJWV8+i0PFR1Wi5RCnPt0YdQWstHuZrxABi45+XVkzKtz3TUc\nYxrvPBucVa6uzd953u8CixNFkiOefvb/dajsv1GIwH6/Cvc1ftz1AgMBAAGgODA2\nBgkqhkiG9w0BCQ4xKTAnMCUGA1UdEQQeMByCDnd3dy53ZXBwb3MubmV0ggp3ZXBw\nb3MubmV0MA0GCSqGSIb3DQEBCwUAA4IBAQCDnVBO9RdJX0eFeZzlv5c8yG8duhKP\nl0Vl+V88fJylb/cbNj9qFPkKTK0vTXmS2XUFBChKPtLucp8+Z754UswX+QCsdc7U\nTTSG0CkyilcSubdZUERGej1XfrVQhrokk7Fu0Jh3BdT6REP0SIDTpA8ku/aRQiAp\np+h19M37S7+w/DMGDAq2LSX8jOpJ1yIokRDyLZpmwyLxutC21DXMGoJ3xZeUFrUT\nqRNwzkn2dJzgTrPkzhaXalUBqv+nfXHqHaWljZa/O0NVCFrHCdTdd53/6EE2Yabv\nq5SFTkRCpaxrvM/7a8Tr4ixD1/VKD6rw3+WC00000000000000000000\n-----END CERTIFICATE REQUEST-----\n","state":"issued","auto_renew":false,"alternate_names":["weppos.net", "www.weppos.net"],"authority_identifier":"letsencrypt","created_at":"2016-06-11T18:47:08Z","updated_at":"2016-06-11T18:47:37Z","expires_on":"2016-09-09"}}
+{"data":{"id":101967,"domain_id":289333,"contact_id":2511,"name":"www","common_name":"www.bingo.pizza","years":1,"csr":"-----BEGIN CERTIFICATE REQUEST-----\nMIICmTCCAYECAQAwGjEYMBYGA1UEAwwPd3d3LmJpbmdvLnBpenphMIIBIjANBgkq\nhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAw4+KoZ9IDCK2o5qAQpi+Icu5kksmjQzx\n5o5g4B6XhRxhsfHlK/i3iU5hc8CONjyVv8j82835RNsiKrflnxGa9SH68vbQfcn4\nIpbMz9c+Eqv5h0Euqlc3A4DBzp0unEu5QAUhR6Xu1TZIWDPjhrBOGiszRlLQcp4F\nzy6fD6j5/d/ylpzTp5v54j+Ey31Bz86IaBPtSpHI+Qk87Hs8DVoWxZk/6RlAkyur\nXDGWnPu9n3RMfs9ag5anFhggLIhCNtVN4+0vpgPQ59pqwYo8TfdYzK7WSKeL7geu\nCqVE3bHAqU6dLtgHOZfTkLwGycUh4p9aawuc6fsXHHYDpIL8s3vAvwIDAQABoDow\nOAYJKoZIhvcNAQkOMSswKTAnBgNVHREEIDAeggtiaW5nby5waXp6YYIPd3d3LmJp\nbmdvLnBpenphMA0GCSqGSIb3DQEBCwUAA4IBAQBwOLKv+PO5hSJkgqS6wL/wRqLh\nQ1zbcHRHAjRjnpRz06cDvN3X3aPI+lpKSNFCI0A1oKJG7JNtgxX3Est66cuO8ESQ\nPIb6WWN7/xlVlBCe7ZkjAFgN6JurFdclwCp/NI5wBCwj1yb3Ar5QQMFIZOezIgTI\nAWkQSfCmgkB96d6QlDWgidYDDjcsXugQveOQRPlHr0TsElu47GakxZdJCFZU+WPM\nodQQf5SaqiIK2YaH1dWO//4KpTS9QoTy1+mmAa27apHcmz6X6+G5dvpHZ1qH14V0\nJoMWIK+39HRPq6mDo1UMVet/xFUUrG/H7/tFlYIDVbSpVlpVAFITd/eQkaW/\n-----END CERTIFICATE REQUEST-----\n","state":"issued","auto_renew":false,"alternate_names":[],"authority_identifier":"letsencrypt","created_at":"2020-06-18T18:54:17Z","updated_at":"2020-06-18T19:10:14Z","expires_at":"2020-09-16T18:10:13Z","expires_on":"2020-09-16"}}

--- a/test/fixtures.http/issueLetsencryptCertificate/success.http
+++ b/test/fixtures.http/issueLetsencryptCertificate/success.http
@@ -1,21 +1,19 @@
 HTTP/1.1 202 Accepted
 Server: nginx
-Date: Wed, 18 Oct 2017 15:42:19 GMT
+Date: Thu, 18 Jun 2020 18:56:21 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
-X-RateLimit-Limit: 2400
-X-RateLimit-Remaining: 2398
-X-RateLimit-Reset: 1508344833
-ETag: W/"2d6bbf090ba2144b097e33cb3d8964e4"
-Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: 50628584-cc2f-4543-8775-4f7c8196078b
-X-Runtime: 0.771481
-X-Content-Type-Options: nosniff
-X-Download-Options: noopen
+X-RateLimit-Limit: 4800
+X-RateLimit-Remaining: 4798
+X-RateLimit-Reset: 1592510057
+Cache-Control: no-cache
+X-Request-Id: 1d6bdd7c-a88e-4ac2-9d12-36699a32b006
+X-Runtime: 0.884870
 X-Frame-Options: DENY
-X-Permitted-Cross-Domain-Policies: none
+X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
-Strict-Transport-Security: max-age=31536000
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
 
-{"data":{"id":200,"domain_id":300,"contact_id":100,"name":"www","common_name":"www.example.com","years":1,"csr":null,"state":"requesting","auto_renew":false,"alternate_names":[],"authority_identifier":"letsencrypt","created_at":"2017-10-18T15:40:32Z","updated_at":"2017-10-18T15:42:18Z","expires_on":null}}
+{"data":{"id":101967,"domain_id":289333,"contact_id":2511,"name":"www","common_name":"www.bingo.pizza","years":1,"csr":null,"state":"requesting","auto_renew":false,"alternate_names":[],"authority_identifier":"letsencrypt","created_at":"2020-06-18T18:54:17Z","updated_at":"2020-06-18T18:56:20Z","expires_at":null,"expires_on":null}}

--- a/test/fixtures.http/issueRenewalLetsencryptCertificate/success.http
+++ b/test/fixtures.http/issueRenewalLetsencryptCertificate/success.http
@@ -1,21 +1,19 @@
 HTTP/1.1 202 Accepted
 Server: nginx
-Date: Thu, 19 Oct 2017 08:22:17 GMT
+Date: Thu, 18 Jun 2020 20:05:26 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
-X-RateLimit-Limit: 2400
-X-RateLimit-Remaining: 2398
-X-RateLimit-Reset: 1508404733
-ETag: W/"8dfa538f5255d47f11d016dbb1c26059"
-Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: 185ad43f-1e34-43fb-a4aa-0359c9f95f2d
-X-Runtime: 0.853294
-X-Content-Type-Options: nosniff
-X-Download-Options: noopen
+X-RateLimit-Limit: 4800
+X-RateLimit-Remaining: 4798
+X-RateLimit-Reset: 1592513780
+Cache-Control: no-cache
+X-Request-Id: a7194bb4-aea4-42c6-846f-cd96f5f3cf5c
+X-Runtime: 0.897152
 X-Frame-Options: DENY
-X-Permitted-Cross-Domain-Policies: none
+X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
-Strict-Transport-Security: max-age=31536000
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
 
-{"data":{"id":999,"domain_id":300,"contact_id":100,"name":"www","common_name":"www.example.com","years":1,"csr":null,"state":"requesting","auto_renew":false,"alternate_names":[],"authority_identifier":"letsencrypt","created_at":"2017-10-19T08:18:53Z","updated_at":"2017-10-19T08:22:17Z","expires_on":null}}
+{"data":{"id":101972,"domain_id":289333,"contact_id":2511,"name":"www","common_name":"www.bingo.pizza","years":1,"csr":null,"state":"requesting","auto_renew":false,"alternate_names":[],"authority_identifier":"letsencrypt","created_at":"2020-06-18T19:56:20Z","updated_at":"2020-06-18T20:05:26Z","expires_at":null,"expires_on":null}}

--- a/test/fixtures.http/listCertificates/success.http
+++ b/test/fixtures.http/listCertificates/success.http
@@ -1,21 +1,21 @@
 HTTP/1.1 200 OK
 Server: nginx
-Date: Fri, 08 Jul 2016 15:38:52 GMT
+Date: Thu, 18 Jun 2020 20:35:23 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
-X-RateLimit-Limit: 2400
-X-RateLimit-Remaining: 2394
-X-RateLimit-Reset: 1467993483
-ETag: W/"69a9ce919d99cc8f27183b74a5eb22a9"
+X-RateLimit-Limit: 4800
+X-RateLimit-Remaining: 4797
+X-RateLimit-Reset: 1592513780
+ETag: W/"29d46b533190f5693be4f1133adf99c0"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: 8936089b-f44a-4303-bb65-b39e835f9973
-X-Runtime: 0.036570
-X-Content-Type-Options: nosniff
-X-Download-Options: noopen
+X-Request-Id: 6f25214b-8e5a-4095-8e44-d7998b05aa8d
+X-Runtime: 0.026239
 X-Frame-Options: DENY
-X-Permitted-Cross-Domain-Policies: none
+X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
 Strict-Transport-Security: max-age=31536000
 
-{"data":[{"id":1,"domain_id":10,"contact_id":3,"name":"www","common_name":"www.weppos.net","years":1,"csr":"-----BEGIN CERTIFICATE REQUEST-----\nMIICljCCAX4CAQAwGTEXMBUGA1UEAwwOd3d3LndlcHBvcy5uZXQwggEiMA0GCSqG\nSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC3MJwx9ahBG3kAwRjQdRvYZqtovUaxY6jp\nhd09975gO+2eYPDbc1yhNftVJ4KBT0zdEqzX0CwIlxE1MsnZ2YOsC7IJO531hMBp\ndBxM4tSG07xPz70AVUi9rY6YCUoJHmxoFbclpHFbtXZocR393WyzUK8047uM2mlz\n03AZKcMdyfeuo2/9TcxpTSCkklGqwqS9wtTogckaDHJDoBunAkMioGfOSMe7Yi6E\nYRtG4yPJYsDaq2yPJWV8+i0PFR1Wi5RCnPt0YdQWstHuZrxABi45+XVkzKtz3TUc\nYxrvPBucVa6uzd953u8CixNFkiOefvb/dajsv1GIwH6/Cvc1ftz1AgMBAAGgODA2\nBgkqhkiG9w0BCQ4xKTAnMCUGA1UdEQQeMByCDnd3dy53ZXBwb3MubmV0ggp3ZXBw\nb3MubmV0MA0GCSqGSIb3DQEBCwUAA4IBAQCDnVBO9RdJX0eFeZzlv5c8yG8duhKP\n0000000000000/cbNj9qFPkKTK0vTXmS2XUFBChKPtLucp8+Z754UswX+QCsdc7U\nTTSG0CkyilcSubdZUERGej1XfrVQhrokk7Fu0Jh3BdT6REP0SIDTpA8ku/aRQiAp\np+h19M37S7+w/DMGDAq2LSX8jOpJ1yIokRDyLZpmwyLxutC21DXMGoJ3xZeUFrUT\nqRNwzkn2dJzgTrPkzhaXalUBqv+nfXHqHaWljZa/O0NVCFrHCdTdd53/6EE2Yabv\nq5SFTkRCpaxrvM/7a8Tr4ixD1/VKD6rw3+WCvyS4GWK7knhiI1nZH3PI\n-----END CERTIFICATE REQUEST-----\n","state":"issued","auto_renew":false,"alternate_names":[],"authority_identifier":"letsencrypt","created_at":"2016-06-11T18:47:08Z","updated_at":"2016-06-11T18:47:37Z","expires_on":"2016-09-09"},{"id":2,"domain_id":10,"contact_id":3,"name":"www","common_name":"www.weppos.net","years":1,"csr":"-----BEGIN CERTIFICATE REQUEST-----\nMIICljCCAX4CAQAwGTEXMBUGA1UEAwwOd3d3LndlcHBvcy5uZXQwggEiMA0GCSqG\nSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDEhv18Sz4nQtjCDseXREuFIZW88yK7M5gM\nw2WuVmxTfn3MGprPtIevPJ0gzR4foMpnOKjR/wW8DpbvvNPNo5FAsYf+mr84rMft\nUjOQWfqcraWWHmss/Ytq45uTie8M1/C4Pr+FFfbOwwWz/DqVao5RQ34q+LIPpV62\nwRkg0m14FqT8gjNNM0XAsrfT7M+kvfsS+FbyJ7G9K0tj3wgqaEuKAQtJn7MPflM8\nfG0TqLJ+NSuI/Zfmtol3XzBD/AoViu0F8Sqp5OR8Ej4ZdmbKR+om+U+MX9LwF8MD\nwCtMAIaGF4JkgrpiGrbAKIpXwkuxJ8wWrkwhxu18z/OhJEBW+wFjAgMBAAGgODA2\nBgkqhkiG9w0BCQ4xKTAnMCUGA1UdEQQeMByCDnd3dy53ZXBwb3MubmV0ggp3ZXBw\nb3MubmV0MA0GCSqGSIb3DQEBCwUAA4IBAQBuDDwhTjU7pAGHU1dUthfznvFqjY2I\n7CNEaUSxlXdxyZs34cwx28F7iMDE8Gh7B3QkuS3c2CTtAQsxnWKebgLYJ8w8XLN1\n9mZtNhT8yXKzLDfC9KuzKw467sbxYf8bLsuyFdQ8sBNp+8es9OwVgYsPwZ4NBtOn\nQlwtBBBdxrF5zCQgQXZsFmymf/o4nLU66ouW1MVjoG608dthoBYiIIiPRx3c+Rjd\ni8JHn2qIKF7AJfJy/H8TLgtE1bt08tfDA9ztuX2zb/lvXrVu4aLBjOF+Fn3b+EqX\n6gR0m+Id0b3t3ORN1QU0SBiyrXXJbo6E+cpYKeWlnkf0000000000000\n-----END CERTIFICATE REQUEST-----\n","state":"issued","auto_renew":false,"alternate_names":[],"authority_identifier":"letsencrypt","created_at":"2016-05-25T15:56:06Z","updated_at":"2016-05-25T17:10:39Z","expires_on":null}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}
+{"data":[{"id":101973,"domain_id":14279,"contact_id":11435,"name":"www2","common_name":"www2.dnsimple.us","years":1,"csr":"-----BEGIN CERTIFICATE REQUEST-----\nMIICYDCCAUgCAQAwGzEZMBcGA1UEAwwQd3d3Mi5kbnNpbXBsZS51czCCASIwDQYJ\nKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMjXrephLTu7OKVQ6F3LhmLkL6NL3ier\n1qaWPtJBbkBuzJIn8gmSG+6xGmywB6GKvP2IVkPQhPBpfc8wsTd26rbSBHnRIQal\ntk+W4aQZyIeXFARY+cRvpjeAtmpX0vwZkDMoEyhFomBfGxVfx6tSqdGlR88/x0By\ny5u7+xwkY+4jMt+wZi+wpXsScumB6DAC1PTYRvNFQy7Gcjqrc3EdzPsn3c9kLCNO\n3GCPJoWmT5Rtyd7FxjJiSIf7BDOi12BnblpSLwGvtu6Wrl+u9LJLj8zeCACwUiQG\nuvnP2lAl2YacNAgpql6C2eEnFjIub7Ul1QMUImQSDVy5dMd/UGQrOb0CAwEAAaAA\nMA0GCSqGSIb3DQEBCwUAA4IBAQA8oVxOrZCGeSFmKpNV4oilzPOepTVSWxXa19T7\nzD/azh6j6RBLZPpG4TFbpvjecum+1V7Y8ypIcwhRtlh5/zSbfJkjJsdCdZU9XZat\nT5YkOaxuCUCDajpRiyyKhHvrloTPKPXe5ygCq/Q23xm//VrXKArLSWVB9qWS6gDV\nk0y3/mIlTQ3mTgfYQySc3MPXvIgUoqmB8Ajfq1n3hSLgb1/OoKNfeVEWsON116cq\nbXvl63+XzPubj6KWZXZH/jhrs53fuLq3xyeeuOaPrn+2VceBVt4DCC9n0JS5wepl\nHDoVxtWTTNeJdP5xFB5V1KI+D4FEFBUGnQABEvajpU3vljh3\n-----END CERTIFICATE REQUEST-----\n","state":"issued","auto_renew":false,"alternate_names":[],"authority_identifier":"letsencrypt","created_at":"2020-06-18T20:15:09Z","updated_at":"2020-06-18T20:30:08Z","expires_at":"2020-09-16T19:30:07Z","expires_on":"2020-09-16"},{"id":101969,"domain_id":14279,"contact_id":11435,"name":"www","common_name":"www.dnsimple.us","years":1,"csr":"-----BEGIN CERTIFICATE REQUEST-----\nMIICmTCCAYECAQAwGjEYMBYGA1UEAwwPd3d3LmRuc2ltcGxlLnVzMIIBIjANBgkq\nhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4rVs1z42xmPj6KdE++D182/wyMH1GG4p\nESK99FQbMimjOvYcidFTySKpSvEv5Dhmj5fb79vogBuCZQetm5Es37Gboc+D02SO\n48uE8LisuYhx1yBKryXSYnVaWz9oxEuVLtf+aq/Yt1HTu3/zzMWKPRN79OmYgWnl\n03ISfDmgzxqViYPIAObge8nB5TzlQbDV9W9eQWs12IYg4pfI+b+c9VrnMYjdz2Lk\nEhIYThIQRSi5IfNbDu8YiG87V0bTtzeT6lq2Lh3+IkyhBkF10xaivnwac1MfK/25\ntZg2PYCzG56Bf3xTtjo5P0Eb7LlBZLlwLs3hXvlU0eV2LAWm38v3wwIDAQABoDow\nOAYJKoZIhvcNAQkOMSswKTAnBgNVHREEIDAeggtkbnNpbXBsZS51c4IPd3d3LmRu\nc2ltcGxlLnVzMA0GCSqGSIb3DQEBCwUAA4IBAQBiYQ5/Dp2JML1UgYmUNqfOfKKV\nZS9HiX1OcR6bkHHIEzDV1iqDdZ/0Uqr7p6rmLkVIaDWUdano2jtMEIRGC1c8q9bH\nRlzubdyYXbBGE+iGho5crzu5Hwit3Z3J2C6f28NvfqN5Ume3jLr90qbG+1HULsUF\nR3tCKTzvvs4QAKXbo+eEafDNFToGzd0cxpesdlzu3zDu5rHfLz862QifmWZzN6JS\nj1/Q+TedS5EknTaOwGjm1od0zuD3YRJ+XzGq1G8MbuxYWXqaGQRo0TzZlYW6Ax1C\n9utnEQ5Uc+z9ejjZSv03p1VzO7bV7AOz3F40M3IfM8qQ4YMeXbGWJ98jrWDe\n-----END CERTIFICATE REQUEST-----\n","state":"issued","auto_renew":false,"alternate_names":[],"authority_identifier":"letsencrypt","created_at":"2020-06-18T19:22:51Z","updated_at":"2020-06-18T19:40:13Z","expires_at":"2020-09-16T18:40:12Z","expires_on":"2020-09-16"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}

--- a/test/fixtures.http/purchaseLetsencryptCertificate/success.http
+++ b/test/fixtures.http/purchaseLetsencryptCertificate/success.http
@@ -1,21 +1,21 @@
 HTTP/1.1 201 Created
 Server: nginx
-Date: Wed, 18 Oct 2017 15:40:32 GMT
+Date: Thu, 18 Jun 2020 18:54:17 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
-X-RateLimit-Limit: 2400
-X-RateLimit-Remaining: 2399
-X-RateLimit-Reset: 1508344832
-ETag: W/"88b289ef19331082113a0c9cb32376da"
+X-RateLimit-Limit: 4800
+X-RateLimit-Remaining: 4799
+X-RateLimit-Reset: 1592510057
+ETag: W/"36ffdd6505ed488a3aeeaace031c5869"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: 119f2d5b-2521-49ec-804d-715a10eeabc6
-X-Runtime: 0.095302
-X-Content-Type-Options: nosniff
-X-Download-Options: noopen
+X-Request-Id: 4e99c95d-6d19-48ea-8d63-e68432631c90
+X-Runtime: 0.098745
 X-Frame-Options: DENY
-X-Permitted-Cross-Domain-Policies: none
+X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":300,"certificate_id":300,"state":"requesting","auto_renew":false,"created_at":"2017-10-19T08:18:53Z","updated_at":"2017-10-19T08:22:17Z","expires_on":null}}
+{"data":{"id":101967,"certificate_id":101967,"state":"new","auto_renew":false,"created_at":"2020-06-18T18:54:17Z","updated_at":"2020-06-18T18:54:17Z"}}

--- a/test/fixtures.http/purchaseRenewalLetsencryptCertificate/success.http
+++ b/test/fixtures.http/purchaseRenewalLetsencryptCertificate/success.http
@@ -1,21 +1,21 @@
 HTTP/1.1 201 Created
 Server: nginx
-Date: Thu, 19 Oct 2017 08:18:53 GMT
+Date: Thu, 18 Jun 2020 19:56:20 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
-X-RateLimit-Limit: 2400
-X-RateLimit-Remaining: 2399
-X-RateLimit-Reset: 1508404733
-ETag: W/"bda500d2cac6b1c4903e77e8113e9cdf"
+X-RateLimit-Limit: 4800
+X-RateLimit-Remaining: 4799
+X-RateLimit-Reset: 1592513780
+ETag: W/"84dd908f85153590082766bd8d1f1056"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: 64115047-ced5-40d1-b673-e2fc51ad7587
-X-Runtime: 0.072374
-X-Content-Type-Options: nosniff
-X-Download-Options: noopen
+X-Request-Id: f43f4d80-a7eb-43d3-b1ec-95eba413894e
+X-Runtime: 0.091216
 X-Frame-Options: DENY
-X-Permitted-Cross-Domain-Policies: none
+X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":999,"old_certificate_id":200,"new_certificate_id":300,"state":"new","auto_renew":false,"created_at":"2017-10-19T08:18:53Z","updated_at":"2017-10-19T08:18:53Z"}}
+{"data":{"id":65082,"old_certificate_id":101967,"new_certificate_id":101972,"state":"new","auto_renew":false,"created_at":"2020-06-18T19:56:20Z","updated_at":"2020-06-18T19:56:20Z"}}


### PR DESCRIPTION
We deprecated expires_on attribute in our documentation and api in
favor of expires_at. This commit introduces the new field in Certificate
response and also updates some fixtures.