### PR TITLE
Release 4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master
 
+## Release 4.2.1
+
+- Bump semistandard from 14.2.0 to 14.2.2
+- Bump nock from 12.0.3 to 13.0.0
+
 ## Release 4.2.0
 
 - CHANGED: Bump mocha from 7.1.2 to 8.0.1

--- a/lib/dnsimple.js
+++ b/lib/dnsimple.js
@@ -18,7 +18,7 @@ const services = {
   zones: require('./dnsimple/zones')
 };
 
-Dnsimple.VERSION = '4.2.0';
+Dnsimple.VERSION = '4.2.1';
 Dnsimple.DEFAULT_TIMEOUT = 120000;
 Dnsimple.DEFAULT_BASE_URL = 'https://api.dnsimple.com';
 Dnsimple.DEFAULT_USER_AGENT = 'dnsimple-node/' + Dnsimple.VERSION;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dnsimple",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dnsimple",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "A Node.JS client for the DNSimple API.",
   "keywords": [
     "dnsimple",


### PR DESCRIPTION
Dependencies have updated: `nock` and `semistandard`.

This bumps to version 4.2.1.