### PR TITLE
Bumps minimum NodeJS version required to v12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: focal
 language: node_js
 
 node_js:
-  - "10"
   - "12"
   - "14"
   - "15"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - NEW: Adds NodeJS v16 to Travis build
 - NEW: Adds NodeJS node (latest) to Travis build
 - CHANGED: Moves lockfileVersion to v2
+- CHANGED: Deprecates support for NodeJS v10 (EOL)
 
 ## Release 4.4.0
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Node.JS client for the [DNSimple API v2](https://developer.dnsimple.com/v2/).
 
 ## Requirements
 
-The dnsimple-node package requires node 10.0.0 or higher.
+The dnsimple-node package requires node 12.0.0 or higher.
 
 You must also have an activated DNSimple account to access the DNSimple API.
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "bugs:": "https://github.com/dnsimple/dnsimple-node/issues",
   "engines": {
-    "node": ">= v10.0.0"
+    "node": ">= v12.0.0"
   },
   "main": "lib/dnsimple.js",
   "files": [


### PR DESCRIPTION
As NodeJS v10 is now EOL, we bump the minimum required version to v12