### PR TITLE
Add support for key-data interface creating delegation signer records

### DIFF
--- a/test/dnsimple/domain_delegation_signer_records_spec.js
+++ b/test/dnsimple/domain_delegation_signer_records_spec.js
@@ -128,6 +128,7 @@ describe('domains', function () {
         expect(dsRecord.digest).to.eq('C1F6E04A5A61FBF65BF9DC8294C363CF11C89E802D926BDAB79C55D27BEFA94F');
         expect(dsRecord.digest_type).to.eq('2');
         expect(dsRecord.keytag).to.eq('44620');
+        expect(dsRecord.public_key).to.eq(null);
         expect(dsRecord.created_at).to.eq('2017-03-03T13:49:58Z');
         expect(dsRecord.updated_at).to.eq('2017-03-03T13:49:58Z');
         done();

--- a/test/fixtures.http/createDelegationSignerRecord/created.http
+++ b/test/fixtures.http/createDelegationSignerRecord/created.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":2,"domain_id":1010,"algorithm":"13","digest":"684a1f049d7d082b7f98691657da5a65764913df7f065f6f8c36edf62d66ca03","digest_type":"2","keytag":"2371","created_at":"2017-03-03T15:24:00Z","updated_at":"2017-03-03T15:24:00Z"}}
+{"data":{"id":2,"domain_id":1010,"algorithm":"13","digest":"684a1f049d7d082b7f98691657da5a65764913df7f065f6f8c36edf62d66ca03","digest_type":"2","keytag":"2371","public_key":null,"created_at":"2017-03-03T15:24:00Z","updated_at":"2017-03-03T15:24:00Z"}}

--- a/test/fixtures.http/getDelegationSignerRecord/success.http
+++ b/test/fixtures.http/getDelegationSignerRecord/success.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":24,"domain_id":1010,"algorithm":"8","digest":"C1F6E04A5A61FBF65BF9DC8294C363CF11C89E802D926BDAB79C55D27BEFA94F","digest_type":"2","keytag":"44620","created_at":"2017-03-03T13:49:58Z","updated_at":"2017-03-03T13:49:58Z"}}
+{"data":{"id":24,"domain_id":1010,"algorithm":"8","digest":"C1F6E04A5A61FBF65BF9DC8294C363CF11C89E802D926BDAB79C55D27BEFA94F","digest_type":"2","keytag":"44620","public_key":null,"created_at":"2017-03-03T13:49:58Z","updated_at":"2017-03-03T13:49:58Z"}}

--- a/test/fixtures.http/getTld/success.http
+++ b/test/fixtures.http/getTld/success.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"tld":"com","tld_type":1,"whois_privacy":true,"auto_renew_only":false,"idn":true,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":true}}
+{"data":{"tld":"com","tld_type":1,"whois_privacy":true,"auto_renew_only":false,"idn":true,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":true,"dnssec_interface_type":"ds"}}

--- a/test/fixtures.http/listDelegationSignerRecords/success.http
+++ b/test/fixtures.http/listDelegationSignerRecords/success.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":[{"id":24,"domain_id":1010,"algorithm":"8","digest":"C1F6E04A5A61FBF65BF9DC8294C363CF11C89E802D926BDAB79C55D27BEFA94F","digest_type":"2","keytag":"44620","created_at":"2017-03-03T13:49:58Z","updated_at":"2017-03-03T13:49:58Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":1,"total_pages":1}}
+{"data":[{"id":24,"domain_id":1010,"algorithm":"8","digest":"C1F6E04A5A61FBF65BF9DC8294C363CF11C89E802D926BDAB79C55D27BEFA94F","digest_type":"2","keytag":"44620","public_key":null,"created_at":"2017-03-03T13:49:58Z","updated_at":"2017-03-03T13:49:58Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":1,"total_pages":1}}

--- a/test/fixtures.http/listTlds/success.http
+++ b/test/fixtures.http/listTlds/success.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":[{"tld":"ac","tld_type":2,"whois_privacy":false,"auto_renew_only":true,"idn":false,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":false},{"tld":"academy","tld_type":3,"whois_privacy":true,"auto_renew_only":false,"idn":true,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":true}],"pagination":{"current_page":1,"per_page":2,"total_entries":195,"total_pages":98}}
+{"data":[{"tld":"ac","tld_type":2,"whois_privacy":false,"auto_renew_only":true,"idn":false,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":false,"dnssec_interface_type":"ds"},{"tld":"academy","tld_type":3,"whois_privacy":true,"auto_renew_only":false,"idn":true,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":true,"dnssec_interface_type":"key"}],"pagination":{"current_page":1,"per_page":2,"total_entries":195,"total_pages":98}}


### PR DESCRIPTION
This PR:

* Updates the fixtures from [dnsimple-developer repo](https://github.com/dnsimple/dnsimple-developer/tree/main/fixtures/v2/api) to reflect the latest changes to our DNSSEC-related APIs.

I was able to verify the changes by enabling DNSSEC on one of our testing .BE domains.