### PR TITLE
Adds the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+---
+name: release
+
+on:
+  push:
+    tags:
+      - v*.*.*
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Set up Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run build --if-present
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ The following instructions uses `$VERSION` as a placeholder, where `$VERSION` is
 
 1. Run the test suite and ensure all the tests pass.
 
-1. Set the version in `package.json`:
+2. Set the version in `package.json`:
 
     ```json
     {
@@ -37,38 +37,33 @@ The following instructions uses `$VERSION` as a placeholder, where `$VERSION` is
     }
     ```
 
-1. Set the version in `lib/dnsimple.js`:
+3. Set the version in `lib/dnsimple.js`:
 
     ```javascript
     Dnsimple.VERSION = '$VERSION';
     ```
 
-1. Run the test suite and ensure all the tests pass.
+4. Run the test suite and ensure all the tests pass.
 
-1. Finalize the `## main` section in `CHANGELOG.md` assigning the version.
+5. Finalize the `## main` section in `CHANGELOG.md` assigning the version.
 
-1. Commit and push the changes
+6. Commit and push the changes
 
     ```shell
     git commit -a -m "Release $VERSION"
     git push origin main
     ```
 
-1. Wait for CI to complete.
+7. Wait for CI to complete.
 
-1. Create a signed tag.
+8. Create a signed tag.
 
     ```shell
     git tag -a v$VERSION -s -m "Release $VERSION"
     git push origin --tags
     ```
 
-1. Release to npm.
-
-    ```shell
-    npm login
-    npm publish
-    ```
+GitHub actions will take it from here and publish to `npm`
 
 ## Testing
 


### PR DESCRIPTION
Adds the automated release workflow.

When a new tag is pushed the release workflow will pick it up and start the releasing of the new version.

Things that need to be done (configuration wise), which I have no access to (we need someone with admin rights on this repo for that):

- [x] add the NPM_TOKEN to the secrets