### PR TITLE
Bumps minimum NodeJS version required to v14 and adds NodeJS v18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     name: Node.js ${{ matrix.node-version }}
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 17.x]
+        node-version: [14.x, 16.x, 17.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     name: Node.js ${{ matrix.node-version }}
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 17.x]
+        node-version: [14.x, 16.x, 17.x, 18.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 ---
 name: release
 
-on:
+"on":
   push:
     tags:
       - v*.*.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## main
 
+- NEW: Adds NodeJS v18 to Travis build
 - CHANGED: Deprecates support for NodeJS v12 (EOL)
 
 ## Release 5.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+- CHANGED: Deprecates support for NodeJS v12 (EOL)
+
 ## Release 5.1.1
 
 - CHANGED: Bump dependency versions

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Node.JS client for the [DNSimple API v2](https://developer.dnsimple.com/v2/).
 
 ## Requirements
 
-The dnsimple-node package requires node 12.0.0 or higher.
+The dnsimple-node package requires node 14.0.0 or higher.
 
 You must also have an activated DNSimple account to access the DNSimple API.
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "bugs:": "https://github.com/dnsimple/dnsimple-node/issues",
   "engines": {
-    "node": ">= v12.0.0"
+    "node": ">= v14.0.0"
   },
   "main": "lib/dnsimple.js",
   "files": [


### PR DESCRIPTION
As NodeJS v12 reached EOL, we are bumping minimum version to v14, plus adding to v18 to CI

re https://nodejs.org/en/about/releases/