### PR TITLE
Review validation errors in HTTP 400 API responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-- CHANGED: Deprecate Certificate's `contact_id` (dnsimple/dnsimple-node#133)
-
 ## main
 
+- CHANGED: Deprecate Certificate's `contact_id` (dnsimple/dnsimple-node#133)
+- CHANGED: Add getter for attribute errors in `error` object (dnsimple/dnsimple-node#150)
+  
 ## Release 6.0.0
 
 - NEW: Adds NodeJS v18 to Travis build

--- a/lib/dnsimple/client.js
+++ b/lib/dnsimple/client.js
@@ -101,6 +101,7 @@ class Client {
           } else if (res.statusCode >= 400 && res.statusCode < 500) {
             error = JSON.parse(data);
             error.description = 'Bad request';
+            error.attributeErrors = error.errors;
             reject.call(this, error);
           } else if (res.statusCode === 204) {
             resolve.call(this, {});

--- a/lib/dnsimple/client.js
+++ b/lib/dnsimple/client.js
@@ -10,35 +10,35 @@ const querystring = require('querystring');
  * the calls to the DNSimple API.
  */
 class Client {
-  constructor (dnsimple) {
+  constructor(dnsimple) {
     this._dnsimple = dnsimple;
   }
 
-  baseUrl () {
+  baseUrl() {
     return this._dnsimple.baseUrl();
   }
 
-  get (path, options) {
+  get(path, options) {
     return this.request('GET', path, null, options);
   }
 
-  post (path, data, options) {
+  post(path, data, options) {
     return this.request('POST', path, data, options);
   }
 
-  put (path, data, options) {
+  put(path, data, options) {
     return this.request('PUT', path, data, options);
   }
 
-  patch (path, data, options) {
+  patch(path, data, options) {
     return this.request('PATCH', path, data, options);
   }
 
-  delete (path, options) {
+  delete(path, options) {
     return this.request('DELETE', path, null, options);
   }
 
-  request (method, path, data, options) {
+  request(method, path, data, options) {
     const timeout = this._dnsimple.timeout;
     const headers = {
       Authorization: `Bearer ${this._dnsimple.accessToken()}`,
@@ -68,22 +68,24 @@ class Client {
     });
   }
 
-  _timeoutHandler (timeout, req, reject) {
+  _timeoutHandler(timeout, req, reject) {
     return () => {
       req._isAborted = true;
       req.abort();
 
-      reject.call(this, { description: 'timeout' });
+      reject.call(this, {description: 'timeout'});
     };
   }
 
-  _responseHandler (req, resolve, reject) {
+  _responseHandler(req, resolve, reject) {
     return (res) => {
       let data = '';
       let error;
 
       res.setEncoding('utf8');
-      res.on('data', (chunk) => { data += chunk; });
+      res.on('data', (chunk) => {
+        data += chunk;
+      });
       res.on('end', () => {
         try {
           if (res.statusCode === 401) {
@@ -95,13 +97,15 @@ class Client {
             error.description = 'Not found';
             reject.call(this, error);
           } else if (res.statusCode === 405) {
-            reject.call(this, { description: 'Method not allowed' });
+            reject.call(this, {description: 'Method not allowed'});
           } else if (res.statusCode === 429) {
-            reject.call(this, { description: 'Too many requests' });
+            reject.call(this, {description: 'Too many requests'});
           } else if (res.statusCode >= 400 && res.statusCode < 500) {
             error = JSON.parse(data);
             error.description = 'Bad request';
-            error.attributeErrors = error.errors;
+            error.attributeErrors = function () {
+              return this.errors;
+            };
             reject.call(this, error);
           } else if (res.statusCode === 204) {
             resolve.call(this, {});
@@ -119,7 +123,7 @@ class Client {
     };
   }
 
-  _errorHandler (req, reject) {
+  _errorHandler(req, reject) {
     return (error) => {
       if (!req._isAborted) {
         const errorObj = {
@@ -131,7 +135,7 @@ class Client {
     };
   }
 
-  _versionedPath (path, options) {
+  _versionedPath(path, options) {
     let versionedPath = '/v2' + path;
     const query = {};
 

--- a/lib/dnsimple/client.js
+++ b/lib/dnsimple/client.js
@@ -10,35 +10,35 @@ const querystring = require('querystring');
  * the calls to the DNSimple API.
  */
 class Client {
-  constructor(dnsimple) {
+  constructor (dnsimple) {
     this._dnsimple = dnsimple;
   }
 
-  baseUrl() {
+  baseUrl () {
     return this._dnsimple.baseUrl();
   }
 
-  get(path, options) {
+  get (path, options) {
     return this.request('GET', path, null, options);
   }
 
-  post(path, data, options) {
+  post (path, data, options) {
     return this.request('POST', path, data, options);
   }
 
-  put(path, data, options) {
+  put (path, data, options) {
     return this.request('PUT', path, data, options);
   }
 
-  patch(path, data, options) {
+  patch (path, data, options) {
     return this.request('PATCH', path, data, options);
   }
 
-  delete(path, options) {
+  delete (path, options) {
     return this.request('DELETE', path, null, options);
   }
 
-  request(method, path, data, options) {
+  request (method, path, data, options) {
     const timeout = this._dnsimple.timeout;
     const headers = {
       Authorization: `Bearer ${this._dnsimple.accessToken()}`,
@@ -68,16 +68,16 @@ class Client {
     });
   }
 
-  _timeoutHandler(timeout, req, reject) {
+  _timeoutHandler (timeout, req, reject) {
     return () => {
       req._isAborted = true;
       req.abort();
 
-      reject.call(this, {description: 'timeout'});
+      reject.call(this, { description: 'timeout' });
     };
   }
 
-  _responseHandler(req, resolve, reject) {
+  _responseHandler (req, resolve, reject) {
     return (res) => {
       let data = '';
       let error;
@@ -97,9 +97,9 @@ class Client {
             error.description = 'Not found';
             reject.call(this, error);
           } else if (res.statusCode === 405) {
-            reject.call(this, {description: 'Method not allowed'});
+            reject.call(this, { description: 'Method not allowed' });
           } else if (res.statusCode === 429) {
-            reject.call(this, {description: 'Too many requests'});
+            reject.call(this, { description: 'Too many requests' });
           } else if (res.statusCode >= 400 && res.statusCode < 500) {
             error = JSON.parse(data);
             error.description = 'Bad request';
@@ -123,7 +123,7 @@ class Client {
     };
   }
 
-  _errorHandler(req, reject) {
+  _errorHandler (req, reject) {
     return (error) => {
       if (!req._isAborted) {
         const errorObj = {
@@ -135,7 +135,7 @@ class Client {
     };
   }
 
-  _versionedPath(path, options) {
+  _versionedPath (path, options) {
     let versionedPath = '/v2' + path;
     const query = {};
 

--- a/test/dnsimple/contacts.spec.js
+++ b/test/dnsimple/contacts.spec.js
@@ -18,7 +18,7 @@ describe('contacts', () => {
         .get('/v2/1010/contacts?page=1')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.contacts.listContacts(accountId, { page: 1 });
+      dnsimple.contacts.listContacts(accountId, {page: 1});
 
       nock.isDone();
       done();
@@ -29,7 +29,7 @@ describe('contacts', () => {
         .get('/v2/1010/contacts?foo=bar')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.contacts.listContacts(accountId, { query: { foo: 'bar' } });
+      dnsimple.contacts.listContacts(accountId, {query: {foo: 'bar'}});
 
       nock.isDone();
       done();
@@ -40,7 +40,7 @@ describe('contacts', () => {
         .get('/v2/1010/contacts?sort=first_name%3Aasc')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.contacts.listContacts(accountId, { sort: 'first_name:asc' });
+      dnsimple.contacts.listContacts(accountId, {sort: 'first_name:asc'});
 
       nock.isDone();
       done();
@@ -51,7 +51,7 @@ describe('contacts', () => {
         .get('/v2/1010/contacts?first_name_like=example')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.contacts.listContacts(accountId, { filter: { first_name_like: 'example' } });
+      dnsimple.contacts.listContacts(accountId, {filter: {first_name_like: 'example'}});
 
       nock.isDone();
       done();
@@ -167,7 +167,7 @@ describe('contacts', () => {
 
   describe('#createContact', () => {
     const accountId = '1010';
-    const attributes = { first_name: 'John', last_name: 'Smith' };
+    const attributes = {first_name: 'John', last_name: 'Smith'};
     const fixture = testUtils.fixture('createContact/created.http');
 
     it('builds the correct request', (done) => {
@@ -198,12 +198,34 @@ describe('contacts', () => {
         done(error);
       });
     });
+
+    it('includes validation errors coming from the API', async () => {
+      const fixture = testUtils.fixture('createContact/error-validation-errors.http');
+
+      nock('https://api.dnsimple.com')
+        .post('/v2/1010/contacts', attributes)
+        .reply(fixture.statusCode, fixture.body);
+
+      return dnsimple.contacts.createContact(accountId, attributes).then(() => {
+        throw new Error("The promise should follow the rejection path");
+      }, (error) => {
+        expect(error.errors.address1).to.deep.eq(["can't be blank"]);
+        expect(error.errors.city).to.deep.eq(["can't be blank"]);
+        expect(error.errors.country).to.deep.eq(["can't be blank"]);
+        expect(error.errors.email).to.deep.eq(["can't be blank", "is an invalid email address"]);
+        expect(error.errors.first_name).to.deep.eq(["can't be blank"]);
+        expect(error.errors.last_name).to.deep.eq(["can't be blank"]);
+        expect(error.errors.phone).to.deep.eq(["can't be blank", "is probably not a phone number"]);
+        expect(error.errors.postal_code).to.deep.eq(["can't be blank"]);
+        expect(error.errors.state_province).to.deep.eq(["can't be blank"]);
+      });
+    });
   });
 
   describe('#updateContact', () => {
     const accountId = '1010';
     const contactId = 1;
-    const attributes = { last_name: 'Buckminster' };
+    const attributes = {last_name: 'Buckminster'};
     const fixture = testUtils.fixture('updateContact/success.http');
 
     it('builds the correct request', (done) => {

--- a/test/dnsimple/contacts.spec.js
+++ b/test/dnsimple/contacts.spec.js
@@ -18,7 +18,7 @@ describe('contacts', () => {
         .get('/v2/1010/contacts?page=1')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.contacts.listContacts(accountId, {page: 1});
+      dnsimple.contacts.listContacts(accountId, { page: 1 });
 
       nock.isDone();
       done();
@@ -29,7 +29,7 @@ describe('contacts', () => {
         .get('/v2/1010/contacts?foo=bar')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.contacts.listContacts(accountId, {query: {foo: 'bar'}});
+      dnsimple.contacts.listContacts(accountId, { query: { foo: 'bar' } });
 
       nock.isDone();
       done();
@@ -40,7 +40,7 @@ describe('contacts', () => {
         .get('/v2/1010/contacts?sort=first_name%3Aasc')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.contacts.listContacts(accountId, {sort: 'first_name:asc'});
+      dnsimple.contacts.listContacts(accountId, { sort: 'first_name:asc' });
 
       nock.isDone();
       done();
@@ -51,7 +51,7 @@ describe('contacts', () => {
         .get('/v2/1010/contacts?first_name_like=example')
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.contacts.listContacts(accountId, {filter: {first_name_like: 'example'}});
+      dnsimple.contacts.listContacts(accountId, { filter: { first_name_like: 'example' } });
 
       nock.isDone();
       done();
@@ -167,7 +167,7 @@ describe('contacts', () => {
 
   describe('#createContact', () => {
     const accountId = '1010';
-    const attributes = {first_name: 'John', last_name: 'Smith'};
+    const attributes = { first_name: 'John', last_name: 'Smith' };
     const fixture = testUtils.fixture('createContact/created.http');
 
     it('builds the correct request', (done) => {
@@ -207,15 +207,15 @@ describe('contacts', () => {
         .reply(fixture.statusCode, fixture.body);
 
       return dnsimple.contacts.createContact(accountId, attributes).then(() => {
-        throw new Error("The promise should follow the rejection path");
+        throw new Error('The promise should follow the rejection path');
       }, (error) => {
         expect(error.errors.address1).to.deep.eq(["can't be blank"]);
         expect(error.errors.city).to.deep.eq(["can't be blank"]);
         expect(error.errors.country).to.deep.eq(["can't be blank"]);
-        expect(error.errors.email).to.deep.eq(["can't be blank", "is an invalid email address"]);
+        expect(error.errors.email).to.deep.eq(["can't be blank", 'is an invalid email address']);
         expect(error.errors.first_name).to.deep.eq(["can't be blank"]);
         expect(error.errors.last_name).to.deep.eq(["can't be blank"]);
-        expect(error.errors.phone).to.deep.eq(["can't be blank", "is probably not a phone number"]);
+        expect(error.errors.phone).to.deep.eq(["can't be blank", 'is probably not a phone number']);
         expect(error.errors.postal_code).to.deep.eq(["can't be blank"]);
         expect(error.errors.state_province).to.deep.eq(["can't be blank"]);
       });
@@ -225,7 +225,7 @@ describe('contacts', () => {
   describe('#updateContact', () => {
     const accountId = '1010';
     const contactId = 1;
-    const attributes = {last_name: 'Buckminster'};
+    const attributes = { last_name: 'Buckminster' };
     const fixture = testUtils.fixture('updateContact/success.http');
 
     it('builds the correct request', (done) => {

--- a/test/dnsimple/contacts.spec.js
+++ b/test/dnsimple/contacts.spec.js
@@ -209,15 +209,15 @@ describe('contacts', () => {
       return dnsimple.contacts.createContact(accountId, attributes).then(() => {
         throw new Error('The promise should follow the rejection path');
       }, (error) => {
-        expect(error.attributeErrors.address1).to.deep.eq(["can't be blank"]);
-        expect(error.attributeErrors.city).to.deep.eq(["can't be blank"]);
-        expect(error.attributeErrors.country).to.deep.eq(["can't be blank"]);
-        expect(error.attributeErrors.email).to.deep.eq(["can't be blank", 'is an invalid email address']);
-        expect(error.attributeErrors.first_name).to.deep.eq(["can't be blank"]);
-        expect(error.attributeErrors.last_name).to.deep.eq(["can't be blank"]);
-        expect(error.attributeErrors.phone).to.deep.eq(["can't be blank", 'is probably not a phone number']);
-        expect(error.attributeErrors.postal_code).to.deep.eq(["can't be blank"]);
-        expect(error.attributeErrors.state_province).to.deep.eq(["can't be blank"]);
+        expect(error.attributeErrors().address1).to.deep.eq(["can't be blank"]);
+        expect(error.attributeErrors().city).to.deep.eq(["can't be blank"]);
+        expect(error.attributeErrors().country).to.deep.eq(["can't be blank"]);
+        expect(error.attributeErrors().email).to.deep.eq(["can't be blank", 'is an invalid email address']);
+        expect(error.attributeErrors().first_name).to.deep.eq(["can't be blank"]);
+        expect(error.attributeErrors().last_name).to.deep.eq(["can't be blank"]);
+        expect(error.attributeErrors().phone).to.deep.eq(["can't be blank", 'is probably not a phone number']);
+        expect(error.attributeErrors().postal_code).to.deep.eq(["can't be blank"]);
+        expect(error.attributeErrors().state_province).to.deep.eq(["can't be blank"]);
       });
     });
   });

--- a/test/dnsimple/contacts.spec.js
+++ b/test/dnsimple/contacts.spec.js
@@ -209,15 +209,15 @@ describe('contacts', () => {
       return dnsimple.contacts.createContact(accountId, attributes).then(() => {
         throw new Error('The promise should follow the rejection path');
       }, (error) => {
-        expect(error.errors.address1).to.deep.eq(["can't be blank"]);
-        expect(error.errors.city).to.deep.eq(["can't be blank"]);
-        expect(error.errors.country).to.deep.eq(["can't be blank"]);
-        expect(error.errors.email).to.deep.eq(["can't be blank", 'is an invalid email address']);
-        expect(error.errors.first_name).to.deep.eq(["can't be blank"]);
-        expect(error.errors.last_name).to.deep.eq(["can't be blank"]);
-        expect(error.errors.phone).to.deep.eq(["can't be blank", 'is probably not a phone number']);
-        expect(error.errors.postal_code).to.deep.eq(["can't be blank"]);
-        expect(error.errors.state_province).to.deep.eq(["can't be blank"]);
+        expect(error.attributeErrors.address1).to.deep.eq(["can't be blank"]);
+        expect(error.attributeErrors.city).to.deep.eq(["can't be blank"]);
+        expect(error.attributeErrors.country).to.deep.eq(["can't be blank"]);
+        expect(error.attributeErrors.email).to.deep.eq(["can't be blank", 'is an invalid email address']);
+        expect(error.attributeErrors.first_name).to.deep.eq(["can't be blank"]);
+        expect(error.attributeErrors.last_name).to.deep.eq(["can't be blank"]);
+        expect(error.attributeErrors.phone).to.deep.eq(["can't be blank", 'is probably not a phone number']);
+        expect(error.attributeErrors.postal_code).to.deep.eq(["can't be blank"]);
+        expect(error.attributeErrors.state_province).to.deep.eq(["can't be blank"]);
       });
     });
   });

--- a/test/fixtures.http/createContact/error-validation-errors.http
+++ b/test/fixtures.http/createContact/error-validation-errors.http
@@ -1,0 +1,18 @@
+HTTP/1.1 400 Bad Request
+Server: nginx
+Date: Wed, 23 Nov 2016 08:12:57 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2396
+X-RateLimit-Reset: 1479892333
+Cache-Control: no-cache
+X-Request-Id: 91dcf81b-5df4-4d45-b37e-446f0c422a27
+X-Runtime: 0.062556
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: DENY
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 1; mode=block
+
+{"message":"Validation failed","errors":{"address1":["can't be blank"],"city":["can't be blank"],"country":["can't be blank"],"email":["can't be blank","is an invalid email address"],"first_name":["can't be blank"],"last_name":["can't be blank"],"phone":["can't be blank","is probably not a phone number"],"postal_code":["can't be blank"],"state_province":["can't be blank"]}}


### PR DESCRIPTION
This PR:
- Adds a new test that verifies that the client will parse validation errors produced by the API into the rejected promise output of the client.
- Adds a getter method in error objects to access any validation errors if present