### PR TITLE
Implement getDomainRegistration and getDomainRenewal APIs

### DIFF
--- a/lib/dnsimple/registrar.js
+++ b/lib/dnsimple/registrar.js
@@ -75,6 +75,28 @@ class Registrar {
   }
 
   /**
+   * Retrieves the details of an existing domain registration.
+   *
+   * @see https://developer.dnsimple.com/v2/registrar/#getDomainRegistration
+   *
+   * @example Get registration 1234 for example.com:
+   * client.registrar.getDomainPrices(1010, "example.com", 1234).then((response) => {
+   *   // handle response
+   * }, (error) => {
+   *   // handle error
+   * });
+   *
+   * @param {number} accountId The account ID
+   * @param {string} domainName The domain name
+   * @param {number} domainRegistration The domain registration ID
+   * @param {Object} [options]
+   * @return {Promise}
+   */
+  getDomainRegistration (accountId, domainName, domainRegistration, options = {}) {
+    return this._client.get(this._registrarPath(accountId, domainName, `registrations/${domainRegistration}`), options);
+  }
+
+  /**
    * Registers a domain.
    *
    * @see https://developer.dnsimple.com/v2/registrar/#register

--- a/lib/dnsimple/registrar.js
+++ b/lib/dnsimple/registrar.js
@@ -80,7 +80,7 @@ class Registrar {
    * @see https://developer.dnsimple.com/v2/registrar/#getDomainRegistration
    *
    * @example Get registration 1234 for example.com:
-   * client.registrar.getDomainPrices(1010, "example.com", 1234).then((response) => {
+   * client.registrar.getDomainRegistration(1010, "example.com", 1234).then((response) => {
    *   // handle response
    * }, (error) => {
    *   // handle error
@@ -94,6 +94,28 @@ class Registrar {
    */
   getDomainRegistration (accountId, domainName, domainRegistration, options = {}) {
     return this._client.get(this._registrarPath(accountId, domainName, `registrations/${domainRegistration}`), options);
+  }
+
+  /**
+   * Retrieves the details of an existing domain renewal.
+   *
+   * @see https://developer.dnsimple.com/v2/registrar/#getDomainRenewal
+   *
+   * @example Get renewal 1234 for example.com:
+   * client.registrar.getDomainRenewal(1010, "example.com", 1234).then((response) => {
+   *   // handle response
+   * }, (error) => {
+   *   // handle error
+   * });
+   *
+   * @param {number} accountId The account ID
+   * @param {string} domainName The domain name
+   * @param {number} domainRenewal The domain registration ID
+   * @param {Object} [options]
+   * @return {Promise}
+   */
+  getDomainRenewal (accountId, domainName, domainRenewal, options = {}) {
+    return this._client.get(this._registrarPath(accountId, domainName, `renewals/${domainRenewal}`), options);
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "mocha": "^10.0.0",
         "nock": "^13.0.0",
         "semistandard": "^16.0.0",
+        "sinon": "^15.0.1",
         "snazzy": "^9.0.0"
       },
       "engines": {
@@ -167,6 +168,41 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-7.0.1.tgz",
+      "integrity": "sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
     },
     "node_modules/@types/json5": {
@@ -1896,6 +1932,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1969,6 +2011,12 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -2024,6 +2072,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "node_modules/lodash.merge": {
@@ -2281,6 +2335,19 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "node_modules/nise": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
+      "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
     "node_modules/nock": {
       "version": "13.3.0",
       "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.0.tgz",
@@ -2514,6 +2581,15 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
     },
     "node_modules/pathval": {
       "version": "1.1.1",
@@ -3219,6 +3295,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sinon": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.0.1.tgz",
+      "integrity": "sha512-PZXKc08f/wcA/BMRGBze2Wmw50CWPiAH3E21EOi4B49vJ616vW4DQh4fQrqsYox2aNR/N3kCqLuB0PwwOucQrg==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "10.0.2",
+        "@sinonjs/samsam": "^7.0.1",
+        "diff": "^5.0.0",
+        "nise": "^5.1.2",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
     "node_modules/slice-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
@@ -3850,6 +3944,41 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
+    },
+    "@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^2.0.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-7.0.1.tgz",
+      "integrity": "sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
     },
     "@types/json5": {
@@ -5090,6 +5219,12 @@
         "call-bind": "^1.0.2"
       }
     },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -5154,6 +5289,12 @@
         "object.assign": "^4.1.2"
       }
     },
+    "just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -5199,6 +5340,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "lodash.merge": {
@@ -5390,6 +5537,19 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "nise": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
+      "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
     "nock": {
       "version": "13.3.0",
       "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.0.tgz",
@@ -5560,6 +5720,15 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      }
     },
     "pathval": {
       "version": "1.1.1",
@@ -6040,6 +6209,20 @@
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
+      }
+    },
+    "sinon": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.0.1.tgz",
+      "integrity": "sha512-PZXKc08f/wcA/BMRGBze2Wmw50CWPiAH3E21EOi4B49vJ616vW4DQh4fQrqsYox2aNR/N3kCqLuB0PwwOucQrg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "10.0.2",
+        "@sinonjs/samsam": "^7.0.1",
+        "diff": "^5.0.0",
+        "nise": "^5.1.2",
+        "supports-color": "^7.2.0"
       }
     },
     "slice-ansi": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "mocha": "^10.0.0",
     "nock": "^13.0.0",
     "semistandard": "^16.0.0",
+    "sinon": "^15.0.1",
     "snazzy": "^9.0.0"
   },
   "license": "MIT",

--- a/test/dnsimple/registrar.spec.js
+++ b/test/dnsimple/registrar.spec.js
@@ -1,9 +1,7 @@
 'use strict';
 
 const testUtils = require('../testUtils');
-const dnsimple = require('../../lib/dnsimple')({
-  accessToken: testUtils.getAccessToken()
-});
+const dnsimple = testUtils.createTestClient();
 
 const expect = require('chai').expect;
 const nock = require('nock');
@@ -115,6 +113,19 @@ describe('registrar', () => {
           done();
         });
       });
+    });
+  });
+
+  describe('#getDomainRegistration', () => {
+    it('calls the correct method', (done) => {
+      // TODO Use shared global client and remove `done()` call once all other tests migrate away from testing fixture responses.
+      const dnsimple = testUtils.createTestClient();
+      const stub = testUtils.stubRequest(dnsimple);
+
+      const options = {};
+      dnsimple.registrar.getDomainRegistration(1010, 'example.com', 1535, options);
+      expect(stub.calledOnceWithExactly('GET', '/1010/registrar/domains/example.com/registrations/1535', null, options)).to.equal(true);
+      done();
     });
   });
 

--- a/test/dnsimple/registrar.spec.js
+++ b/test/dnsimple/registrar.spec.js
@@ -129,6 +129,19 @@ describe('registrar', () => {
     });
   });
 
+  describe('#getDomainRenewal', () => {
+    it('calls the correct method', (done) => {
+      // TODO Use shared global client and remove `done()` call once all other tests migrate away from testing fixture responses.
+      const dnsimple = testUtils.createTestClient();
+      const stub = testUtils.stubRequest(dnsimple);
+
+      const options = {};
+      dnsimple.registrar.getDomainRenewal(1023, 'example.com', 1694, options);
+      expect(stub.calledOnceWithExactly('GET', '/1023/registrar/domains/example.com/renewals/1694', null, options)).to.equal(true);
+      done();
+    });
+  });
+
   describe('#registerDomain', () => {
     const fixture = testUtils.fixture('registerDomain/success.http');
 

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -3,14 +3,24 @@
 require('mocha');
 require('chai').use(require('chai-as-promised'));
 
+const DNSimple = require('../lib/dnsimple');
 const fs = require('fs');
+const sinon = require('sinon');
+
+const getAccessToken = () => process.env.TOKEN || 'bogus';
 
 module.exports = {
+  createTestClient: () => new DNSimple({
+    accessToken: getAccessToken()
+  }),
 
-  getAccessToken: () => {
-    const key = process.env.TOKEN || 'bogus';
-    return key;
+  stubRequest: (client) => {
+    const stub = sinon.stub();
+    client.registrar._client.request = stub;
+    return stub;
   },
+
+  getAccessToken,
 
   fixture: (path) => {
     const data = fs.readFileSync('./test/fixtures.http/' + path, { encoding: 'UTF8' });


### PR DESCRIPTION
Implement the `getDomainRegistration` and `getDomainRenewal` API methods.

We're starting to test the library in a new way, by testing the network request only, as our library does not handle responses for each method specifically, so current response tests do not test actual code. For example, we generically deserialise all responses into an untyped object and do not actually map and validate fields, which is standard JS. Currently, we also don't sync the fixtures, so our tests don't reflect the actual current API schema.

We will test this by using `sinon` to mock the client request function to ensure that the network requests exactly match. Our plan is to slowly migrate existing tests towards this model.