### PR TITLE
Extract TypeScript types to separate file and declare enum type values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## main
 
+FEATURES
+
+- Most TypeScript types have been named and exported, instead of being inline anonymous types that are hard to reference and use. (dnsimple/dnsimple-node#175)
+- Enum type values are now declared, instead of a generic `string` or `number`, allowing for better type checking and autocomplete. (dnsimple/dnsimple-node#175)
+
 ## 7.0.0
 
 This is a major change that brings TypeScript support as well as many quality-of-life improvements and internal improvements. For details on important changes and how to migrate, see [UPGRADE.md](./UPGRADE.md). For the full breakdown of all changes in detail, see the PR (dnsimple/dnsimple-node#170). Here are the major noteworthy changes:

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -1,5 +1,5 @@
-import type * as types from "./types";
 import type { DNSimple, QueryParams } from "./main";
+import type * as types from "./types";
 
 export class Accounts {
   constructor(private readonly _client: DNSimple) {}

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -1,3 +1,4 @@
+import type * as types from "./types";
 import type { DNSimple, QueryParams } from "./main";
 
 export class Accounts {
@@ -15,15 +16,8 @@ export class Accounts {
   listAccounts = (() => {
     const method = (
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: Array<{
-        id: number;
-        email: string;
-        plan_identifier: string;
-        created_at: string;
-        updated_at: string;
-      }>;
-    }> => this._client.request("GET", `/accounts`, null, params);
+    ): Promise<{ data: Array<types.Account> }> =>
+      this._client.request("GET", `/accounts`, null, params);
     return method;
   })();
 }

--- a/lib/certificates.ts
+++ b/lib/certificates.ts
@@ -1,3 +1,4 @@
+import type * as types from "./types";
 import type { DNSimple, QueryParams } from "./main";
 import { paginate } from "./paginate";
 
@@ -24,29 +25,8 @@ export class Certificates {
       domain: string,
       params: QueryParams & { sort?: string } = {}
     ): Promise<{
-      data: Array<{
-        id: number;
-        domain_id: number;
-        contact_id: number;
-        name: string;
-        common_name: string;
-        years: number;
-        csr: string;
-        state: string;
-        auto_renew: boolean;
-        alternate_names: Array<string>;
-        authority_identifier: string;
-        created_at: string;
-        updated_at: string;
-        expires_at: string;
-        expires_on: string;
-      }>;
-      pagination: {
-        current_page: number;
-        per_page: number;
-        total_entries: number;
-        total_pages: number;
-      };
+      data: Array<types.Certificate>;
+      pagination: types.Pagination;
     }> =>
       this._client.request(
         "GET",
@@ -92,25 +72,7 @@ export class Certificates {
       domain: string,
       certificate: number,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        domain_id: number;
-        contact_id: number;
-        name: string;
-        common_name: string;
-        years: number;
-        csr: string;
-        state: string;
-        auto_renew: boolean;
-        alternate_names: Array<string>;
-        authority_identifier: string;
-        created_at: string;
-        updated_at: string;
-        expires_at: string;
-        expires_on: string;
-      };
-    }> =>
+    ): Promise<{ data: types.Certificate }> =>
       this._client.request(
         "GET",
         `/${account}/domains/${domain}/certificates/${certificate}`,
@@ -138,9 +100,7 @@ export class Certificates {
       domain: string,
       certificate: number,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: { server: string; root: string | null; chain: Array<string> };
-    }> =>
+    ): Promise<{ data: types.CertificateDownload }> =>
       this._client.request(
         "GET",
         `/${account}/domains/${domain}/certificates/${certificate}/download`,
@@ -168,7 +128,7 @@ export class Certificates {
       domain: string,
       certificate: number,
       params: QueryParams & {} = {}
-    ): Promise<{ data: { private_key: string } }> =>
+    ): Promise<{ data: types.CertificatePrivateKey }> =>
       this._client.request(
         "GET",
         `/${account}/domains/${domain}/certificates/${certificate}/private_key`,
@@ -193,23 +153,14 @@ export class Certificates {
     const method = (
       account: number,
       domain: string,
-      data: {
+      data: Partial<{
         auto_renew?: boolean;
         name?: string;
         alternate_names?: Array<string>;
         signature_algorithm?: string;
-      },
+      }>,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        certificate_id: number;
-        state: string;
-        auto_renew: boolean;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+    ): Promise<{ data: types.LetsencryptCertificatePurchase }> =>
       this._client.request(
         "POST",
         `/${account}/domains/${domain}/certificates/letsencrypt`,
@@ -237,25 +188,7 @@ export class Certificates {
       domain: string,
       purchaseId: number,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        domain_id: number;
-        contact_id: number;
-        name: string;
-        common_name: string;
-        years: number;
-        csr: string;
-        state: string;
-        auto_renew: boolean;
-        alternate_names: Array<string>;
-        authority_identifier: string;
-        created_at: string;
-        updated_at: string;
-        expires_at: string;
-        expires_on: string;
-      };
-    }> =>
+    ): Promise<{ data: types.Certificate }> =>
       this._client.request(
         "POST",
         `/${account}/domains/${domain}/certificates/letsencrypt/${purchaseId}/issue`,
@@ -282,19 +215,9 @@ export class Certificates {
       account: number,
       domain: string,
       certificate: number,
-      data: { auto_renew?: boolean; signature_algorithm?: string },
+      data: Partial<{ auto_renew?: boolean; signature_algorithm?: string }>,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        old_certificate_id: number;
-        new_certificate_id: number;
-        state: string;
-        auto_renew: boolean;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+    ): Promise<{ data: types.LetsencryptCertificateRenewal }> =>
       this._client.request(
         "POST",
         `/${account}/domains/${domain}/certificates/letsencrypt/${certificate}/renewals`,
@@ -324,25 +247,7 @@ export class Certificates {
       certificate: number,
       renewalId: number,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        domain_id: number;
-        contact_id: number;
-        name: string;
-        common_name: string;
-        years: number;
-        csr: string;
-        state: string;
-        auto_renew: boolean;
-        alternate_names: Array<string>;
-        authority_identifier: string;
-        created_at: string;
-        updated_at: string;
-        expires_at: string;
-        expires_on: string;
-      };
-    }> =>
+    ): Promise<{ data: types.Certificate }> =>
       this._client.request(
         "POST",
         `/${account}/domains/${domain}/certificates/letsencrypt/${certificate}/renewals/${renewalId}/issue`,

--- a/lib/certificates.ts
+++ b/lib/certificates.ts
@@ -1,6 +1,6 @@
-import type * as types from "./types";
 import type { DNSimple, QueryParams } from "./main";
 import { paginate } from "./paginate";
+import type * as types from "./types";
 
 export class Certificates {
   constructor(private readonly _client: DNSimple) {}
@@ -23,7 +23,15 @@ export class Certificates {
     const method = (
       account: number,
       domain: string,
-      params: QueryParams & { sort?: string } = {}
+      params: QueryParams & {
+        sort?:
+          | "id:asc"
+          | "id:desc"
+          | "common_name:asc"
+          | "common_name:desc"
+          | "expiration:asc"
+          | "expiration:desc";
+      } = {}
     ): Promise<{
       data: Array<types.Certificate>;
       pagination: types.Pagination;
@@ -37,13 +45,29 @@ export class Certificates {
     method.iterateAll = (
       account: number,
       domain: string,
-      params: QueryParams & { sort?: string } = {}
+      params: QueryParams & {
+        sort?:
+          | "id:asc"
+          | "id:desc"
+          | "common_name:asc"
+          | "common_name:desc"
+          | "expiration:asc"
+          | "expiration:desc";
+      } = {}
     ) =>
       paginate((page) => method(account, domain, { ...params, page } as any));
     method.collectAll = async (
       account: number,
       domain: string,
-      params: QueryParams & { sort?: string } = {}
+      params: QueryParams & {
+        sort?:
+          | "id:asc"
+          | "id:desc"
+          | "common_name:asc"
+          | "common_name:desc"
+          | "expiration:asc"
+          | "expiration:desc";
+      } = {}
     ) => {
       const items = [];
       for await (const item of method.iterateAll(account, domain, params)) {

--- a/lib/contacts.ts
+++ b/lib/contacts.ts
@@ -1,6 +1,6 @@
-import type * as types from "./types";
 import type { DNSimple, QueryParams } from "./main";
 import { paginate } from "./paginate";
+import type * as types from "./types";
 
 export class Contacts {
   constructor(private readonly _client: DNSimple) {}
@@ -21,16 +21,40 @@ export class Contacts {
   listContacts = (() => {
     const method = (
       account: number,
-      params: QueryParams & { sort?: string } = {}
+      params: QueryParams & {
+        sort?:
+          | "id:asc"
+          | "id:desc"
+          | "label:asc"
+          | "label:desc"
+          | "email:asc"
+          | "email:desc";
+      } = {}
     ): Promise<{ data: Array<types.Contact>; pagination: types.Pagination }> =>
       this._client.request("GET", `/${account}/contacts`, null, params);
     method.iterateAll = (
       account: number,
-      params: QueryParams & { sort?: string } = {}
+      params: QueryParams & {
+        sort?:
+          | "id:asc"
+          | "id:desc"
+          | "label:asc"
+          | "label:desc"
+          | "email:asc"
+          | "email:desc";
+      } = {}
     ) => paginate((page) => method(account, { ...params, page } as any));
     method.collectAll = async (
       account: number,
-      params: QueryParams & { sort?: string } = {}
+      params: QueryParams & {
+        sort?:
+          | "id:asc"
+          | "id:desc"
+          | "label:asc"
+          | "label:desc"
+          | "email:asc"
+          | "email:desc";
+      } = {}
     ) => {
       const items = [];
       for await (const item of method.iterateAll(account, params)) {

--- a/lib/contacts.ts
+++ b/lib/contacts.ts
@@ -1,3 +1,4 @@
+import type * as types from "./types";
 import type { DNSimple, QueryParams } from "./main";
 import { paginate } from "./paginate";
 
@@ -21,34 +22,8 @@ export class Contacts {
     const method = (
       account: number,
       params: QueryParams & { sort?: string } = {}
-    ): Promise<{
-      data: Array<{
-        id: number;
-        account_id: number;
-        label: string;
-        first_name: string;
-        last_name: string;
-        organization_name: string;
-        job_title: string;
-        address1: string;
-        address2: string;
-        city: string;
-        state_province: string;
-        postal_code: string;
-        country: string;
-        phone: string;
-        fax: string;
-        email: string;
-        created_at: string;
-        updated_at: string;
-      }>;
-      pagination: {
-        current_page: number;
-        per_page: number;
-        total_entries: number;
-        total_pages: number;
-      };
-    }> => this._client.request("GET", `/${account}/contacts`, null, params);
+    ): Promise<{ data: Array<types.Contact>; pagination: types.Pagination }> =>
+      this._client.request("GET", `/${account}/contacts`, null, params);
     method.iterateAll = (
       account: number,
       params: QueryParams & { sort?: string } = {}
@@ -79,45 +54,25 @@ export class Contacts {
   createContact = (() => {
     const method = (
       account: number,
-      data: {
+      data: Partial<{
         label?: string;
-        first_name?: string;
-        last_name?: string;
-        address1?: string;
-        address2?: string | null;
-        city?: string;
-        state_province?: string;
-        postal_code?: string;
-        country?: string;
-        email?: string;
-        phone?: string;
-        fax?: string | null;
-        organization_name?: string;
-        job_title?: string;
-      },
-      params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        account_id: number;
-        label: string;
         first_name: string;
         last_name: string;
-        organization_name: string;
-        job_title: string;
         address1: string;
-        address2: string;
+        address2: string | null;
         city: string;
         state_province: string;
         postal_code: string;
         country: string;
-        phone: string;
-        fax: string;
         email: string;
-        created_at: string;
-        updated_at: string;
-      };
-    }> => this._client.request("POST", `/${account}/contacts`, data, params);
+        phone: string;
+        fax: string | null;
+        organization_name: string;
+        job_title: string;
+      }>,
+      params: QueryParams & {} = {}
+    ): Promise<{ data: types.Contact }> =>
+      this._client.request("POST", `/${account}/contacts`, data, params);
     return method;
   })();
 
@@ -137,28 +92,7 @@ export class Contacts {
       account: number,
       contact: number,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        account_id: number;
-        label: string;
-        first_name: string;
-        last_name: string;
-        organization_name: string;
-        job_title: string;
-        address1: string;
-        address2: string;
-        city: string;
-        state_province: string;
-        postal_code: string;
-        country: string;
-        phone: string;
-        fax: string;
-        email: string;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+    ): Promise<{ data: types.Contact }> =>
       this._client.request(
         "GET",
         `/${account}/contacts/${contact}`,
@@ -183,45 +117,24 @@ export class Contacts {
     const method = (
       account: number,
       contact: number,
-      data: {
+      data: Partial<{
         label?: string;
-        first_name?: string;
-        last_name?: string;
-        address1?: string;
-        address2?: string | null;
-        city?: string;
-        state_province?: string;
-        postal_code?: string;
-        country?: string;
-        email?: string;
-        phone?: string;
-        fax?: string | null;
-        organization_name?: string;
-        job_title?: string;
-      },
-      params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        account_id: number;
-        label: string;
         first_name: string;
         last_name: string;
-        organization_name: string;
-        job_title: string;
         address1: string;
-        address2: string;
+        address2: string | null;
         city: string;
         state_province: string;
         postal_code: string;
         country: string;
-        phone: string;
-        fax: string;
         email: string;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+        phone: string;
+        fax: string | null;
+        organization_name: string;
+        job_title: string;
+      }>,
+      params: QueryParams & {} = {}
+    ): Promise<{ data: types.Contact }> =>
       this._client.request(
         "PATCH",
         `/${account}/contacts/${contact}`,

--- a/lib/domains.ts
+++ b/lib/domains.ts
@@ -1,6 +1,6 @@
-import type * as types from "./types";
 import type { DNSimple, QueryParams } from "./main";
 import { paginate } from "./paginate";
+import type * as types from "./types";
 
 export class Domains {
   constructor(private readonly _client: DNSimple) {}
@@ -26,7 +26,13 @@ export class Domains {
       params: QueryParams & {
         name_like?: string;
         registrant_id?: number;
-        sort?: string;
+        sort?:
+          | "id:asc"
+          | "id:desc"
+          | "name:asc"
+          | "name:desc"
+          | "expiration:asc"
+          | "expiration:desc";
       } = {}
     ): Promise<{ data: Array<types.Domain>; pagination: types.Pagination }> =>
       this._client.request("GET", `/${account}/domains`, null, params);
@@ -35,7 +41,13 @@ export class Domains {
       params: QueryParams & {
         name_like?: string;
         registrant_id?: number;
-        sort?: string;
+        sort?:
+          | "id:asc"
+          | "id:desc"
+          | "name:asc"
+          | "name:desc"
+          | "expiration:asc"
+          | "expiration:desc";
       } = {}
     ) => paginate((page) => method(account, { ...params, page } as any));
     method.collectAll = async (
@@ -43,7 +55,13 @@ export class Domains {
       params: QueryParams & {
         name_like?: string;
         registrant_id?: number;
-        sort?: string;
+        sort?:
+          | "id:asc"
+          | "id:desc"
+          | "name:asc"
+          | "name:desc"
+          | "expiration:asc"
+          | "expiration:desc";
       } = {}
     ) => {
       const items = [];
@@ -332,7 +350,9 @@ export class Domains {
     const method = (
       account: number,
       domain: string,
-      params: QueryParams & { sort?: string } = {}
+      params: QueryParams & {
+        sort?: "id:asc" | "id:desc" | "created_at:asc" | "created_at:desc";
+      } = {}
     ): Promise<{
       data: Array<types.DelegationSigner>;
       pagination: types.Pagination;
@@ -346,13 +366,17 @@ export class Domains {
     method.iterateAll = (
       account: number,
       domain: string,
-      params: QueryParams & { sort?: string } = {}
+      params: QueryParams & {
+        sort?: "id:asc" | "id:desc" | "created_at:asc" | "created_at:desc";
+      } = {}
     ) =>
       paginate((page) => method(account, domain, { ...params, page } as any));
     method.collectAll = async (
       account: number,
       domain: string,
-      params: QueryParams & { sort?: string } = {}
+      params: QueryParams & {
+        sort?: "id:asc" | "id:desc" | "created_at:asc" | "created_at:desc";
+      } = {}
     ) => {
       const items = [];
       for await (const item of method.iterateAll(account, domain, params)) {
@@ -470,7 +494,15 @@ export class Domains {
     const method = (
       account: number,
       domain: string,
-      params: QueryParams & { sort?: string } = {}
+      params: QueryParams & {
+        sort?:
+          | "id:asc"
+          | "id:desc"
+          | "from:asc"
+          | "from:desc"
+          | "to:asc"
+          | "to:desc";
+      } = {}
     ): Promise<{
       data: Array<types.EmailForward>;
       pagination: types.Pagination;
@@ -484,13 +516,29 @@ export class Domains {
     method.iterateAll = (
       account: number,
       domain: string,
-      params: QueryParams & { sort?: string } = {}
+      params: QueryParams & {
+        sort?:
+          | "id:asc"
+          | "id:desc"
+          | "from:asc"
+          | "from:desc"
+          | "to:asc"
+          | "to:desc";
+      } = {}
     ) =>
       paginate((page) => method(account, domain, { ...params, page } as any));
     method.collectAll = async (
       account: number,
       domain: string,
-      params: QueryParams & { sort?: string } = {}
+      params: QueryParams & {
+        sort?:
+          | "id:asc"
+          | "id:desc"
+          | "from:asc"
+          | "from:desc"
+          | "to:asc"
+          | "to:desc";
+      } = {}
     ) => {
       const items = [];
       for await (const item of method.iterateAll(account, domain, params)) {

--- a/lib/domains.ts
+++ b/lib/domains.ts
@@ -1,3 +1,4 @@
+import type * as types from "./types";
 import type { DNSimple, QueryParams } from "./main";
 import { paginate } from "./paginate";
 
@@ -27,28 +28,8 @@ export class Domains {
         registrant_id?: number;
         sort?: string;
       } = {}
-    ): Promise<{
-      data: Array<{
-        id: number;
-        account_id: number;
-        registrant_id: number | null;
-        name: string;
-        unicode_name: string;
-        state: string;
-        auto_renew: boolean;
-        private_whois: boolean;
-        expires_at: string | null;
-        expires_on: string;
-        created_at: string;
-        updated_at: string;
-      }>;
-      pagination: {
-        current_page: number;
-        per_page: number;
-        total_entries: number;
-        total_pages: number;
-      };
-    }> => this._client.request("GET", `/${account}/domains`, null, params);
+    ): Promise<{ data: Array<types.Domain>; pagination: types.Pagination }> =>
+      this._client.request("GET", `/${account}/domains`, null, params);
     method.iterateAll = (
       account: number,
       params: QueryParams & {
@@ -87,24 +68,10 @@ export class Domains {
   createDomain = (() => {
     const method = (
       account: number,
-      data: { name?: string },
+      data: Partial<{ name: string }>,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        account_id: number;
-        registrant_id: number | null;
-        name: string;
-        unicode_name: string;
-        state: string;
-        auto_renew: boolean;
-        private_whois: boolean;
-        expires_at: string | null;
-        expires_on: string;
-        created_at: string;
-        updated_at: string;
-      };
-    }> => this._client.request("POST", `/${account}/domains`, data, params);
+    ): Promise<{ data: types.Domain }> =>
+      this._client.request("POST", `/${account}/domains`, data, params);
     return method;
   })();
 
@@ -124,22 +91,7 @@ export class Domains {
       account: number,
       domain: string,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        account_id: number;
-        registrant_id: number | null;
-        name: string;
-        unicode_name: string;
-        state: string;
-        auto_renew: boolean;
-        private_whois: boolean;
-        expires_at: string | null;
-        expires_on: string;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+    ): Promise<{ data: types.Domain }> =>
       this._client.request(
         "GET",
         `/${account}/domains/${domain}`,
@@ -194,23 +146,8 @@ export class Domains {
       domain: string,
       params: QueryParams & {} = {}
     ): Promise<{
-      data: Array<{
-        id: number;
-        domain_id: number;
-        domain_name: string;
-        user_id: number;
-        user_email: string;
-        invitation: boolean;
-        created_at: string;
-        updated_at: string;
-        accepted_at: string;
-      }>;
-      pagination: {
-        current_page: number;
-        per_page: number;
-        total_entries: number;
-        total_pages: number;
-      };
+      data: Array<types.Collaborator>;
+      pagination: types.Pagination;
     }> =>
       this._client.request(
         "GET",
@@ -255,21 +192,9 @@ export class Domains {
     const method = (
       account: number,
       domain: string,
-      data: { email?: string },
+      data: Partial<{ email: string }>,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        domain_id: number;
-        domain_name: string;
-        user_id: number;
-        user_email: string;
-        invitation: boolean;
-        created_at: string;
-        updated_at: string;
-        accepted_at: string;
-      };
-    }> =>
+    ): Promise<{ data: types.Collaborator }> =>
       this._client.request(
         "POST",
         `/${account}/domains/${domain}/collaborators`,
@@ -323,9 +248,7 @@ export class Domains {
       account: number,
       domain: string,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: { enabled: boolean; created_at: string; updated_at: string };
-    }> =>
+    ): Promise<{ data: types.DNSSEC }> =>
       this._client.request(
         "GET",
         `/${account}/domains/${domain}/dnssec`,
@@ -353,9 +276,7 @@ export class Domains {
       account: number,
       domain: string,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: { enabled: boolean; created_at: string; updated_at: string };
-    }> =>
+    ): Promise<{ data: types.DNSSEC }> =>
       this._client.request(
         "POST",
         `/${account}/domains/${domain}/dnssec`,
@@ -413,23 +334,8 @@ export class Domains {
       domain: string,
       params: QueryParams & { sort?: string } = {}
     ): Promise<{
-      data: Array<{
-        id: number;
-        domain_id: number;
-        algorithm: string;
-        digest: string;
-        digest_type: string;
-        keytag: string;
-        public_key: string;
-        created_at: string;
-        updated_at: string;
-      }>;
-      pagination: {
-        current_page: number;
-        per_page: number;
-        total_entries: number;
-        total_pages: number;
-      };
+      data: Array<types.DelegationSigner>;
+      pagination: types.Pagination;
     }> =>
       this._client.request(
         "GET",
@@ -472,27 +378,15 @@ export class Domains {
     const method = (
       account: number,
       domain: string,
-      data: {
-        algorithm?: string;
-        digest?: string;
-        digest_type?: string;
-        keytag?: string;
-        public_key?: string;
-      },
-      params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        domain_id: number;
+      data: Partial<{
         algorithm: string;
         digest: string;
         digest_type: string;
         keytag: string;
         public_key: string;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+      }>,
+      params: QueryParams & {} = {}
+    ): Promise<{ data: types.DelegationSigner }> =>
       this._client.request(
         "POST",
         `/${account}/domains/${domain}/ds_records`,
@@ -520,19 +414,7 @@ export class Domains {
       domain: string,
       ds: number,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        domain_id: number;
-        algorithm: string;
-        digest: string;
-        digest_type: string;
-        keytag: string;
-        public_key: string;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+    ): Promise<{ data: types.DelegationSigner }> =>
       this._client.request(
         "GET",
         `/${account}/domains/${domain}/ds_records/${ds}`,
@@ -590,22 +472,8 @@ export class Domains {
       domain: string,
       params: QueryParams & { sort?: string } = {}
     ): Promise<{
-      data: Array<{
-        id: number;
-        domain_id: number;
-        alias_email: string;
-        destination_email: string;
-        from: string;
-        to: string;
-        created_at: string;
-        updated_at: string;
-      }>;
-      pagination: {
-        current_page: number;
-        per_page: number;
-        total_entries: number;
-        total_pages: number;
-      };
+      data: Array<types.EmailForward>;
+      pagination: types.Pagination;
     }> =>
       this._client.request(
         "GET",
@@ -648,20 +516,9 @@ export class Domains {
     const method = (
       account: number,
       domain: string,
-      data: { alias_name?: string; destination_email?: string },
+      data: Partial<{ alias_name: string; destination_email: string }>,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        domain_id: number;
-        alias_email: string;
-        destination_email: string;
-        from: string;
-        to: string;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+    ): Promise<{ data: types.EmailForward }> =>
       this._client.request(
         "POST",
         `/${account}/domains/${domain}/email_forwards`,
@@ -689,18 +546,7 @@ export class Domains {
       domain: string,
       emailforward: number,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        domain_id: number;
-        alias_email: string;
-        destination_email: string;
-        from: string;
-        to: string;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+    ): Promise<{ data: types.EmailForward }> =>
       this._client.request(
         "GET",
         `/${account}/domains/${domain}/email_forwards/${emailforward}`,
@@ -753,19 +599,9 @@ export class Domains {
     const method = (
       account: number,
       domain: string,
-      data: { new_account_email?: string },
+      data: Partial<{ new_account_email: string }>,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        domain_id: number;
-        contact_id: number;
-        account_id: number;
-        created_at: string;
-        updated_at: string;
-        accepted_at: string | null;
-      };
-    }> =>
+    ): Promise<{ data: types.Push }> =>
       this._client.request(
         "POST",
         `/${account}/domains/${domain}/pushes`,
@@ -791,23 +627,8 @@ export class Domains {
     const method = (
       account: number,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: Array<{
-        id: number;
-        domain_id: number;
-        contact_id: number;
-        account_id: number;
-        created_at: string;
-        updated_at: string;
-        accepted_at: string | null;
-      }>;
-      pagination: {
-        current_page: number;
-        per_page: number;
-        total_entries: number;
-        total_pages: number;
-      };
-    }> => this._client.request("GET", `/${account}/pushes`, null, params);
+    ): Promise<{ data: Array<types.Push>; pagination: types.Pagination }> =>
+      this._client.request("GET", `/${account}/pushes`, null, params);
     method.iterateAll = (account: number, params: QueryParams & {} = {}) =>
       paginate((page) => method(account, { ...params, page } as any));
     method.collectAll = async (
@@ -838,7 +659,7 @@ export class Domains {
     const method = (
       account: number,
       push: number,
-      data: { contact_id?: number },
+      data: Partial<{ contact_id: number }>,
       params: QueryParams & {} = {}
     ): Promise<{}> =>
       this._client.request("POST", `/${account}/pushes/${push}`, data, params);

--- a/lib/identity.ts
+++ b/lib/identity.ts
@@ -1,5 +1,5 @@
-import type * as types from "./types";
 import type { DNSimple, QueryParams } from "./main";
+import type * as types from "./types";
 
 export class Identity {
   constructor(private readonly _client: DNSimple) {}

--- a/lib/identity.ts
+++ b/lib/identity.ts
@@ -1,3 +1,4 @@
+import type * as types from "./types";
 import type { DNSimple, QueryParams } from "./main";
 
 export class Identity {
@@ -15,23 +16,8 @@ export class Identity {
   whoami = (() => {
     const method = (
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        account: {
-          id: number;
-          email: string;
-          plan_identifier: string;
-          created_at: string;
-          updated_at: string;
-        };
-        user: {
-          id: number;
-          email: string;
-          created_at: string;
-          updated_at: string;
-        };
-      };
-    }> => this._client.request("GET", `/whoami`, null, params);
+    ): Promise<{ data: { account: types.Account; user: types.User } }> =>
+      this._client.request("GET", `/whoami`, null, params);
     return method;
   })();
 }

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -13,7 +13,7 @@ import { VanityNameServers } from "./vanity_name_servers";
 import { Webhooks } from "./webhooks";
 import { Zones } from "./zones";
 
-export * as types from "./types";
+export * from "./types";
 
 export type QueryParams = {
   [name: string]: string | boolean | number | null | undefined;

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -13,6 +13,8 @@ import { VanityNameServers } from "./vanity_name_servers";
 import { Webhooks } from "./webhooks";
 import { Zones } from "./zones";
 
+export * as types from "./types";
+
 export type QueryParams = {
   [name: string]: string | boolean | number | null | undefined;
 };

--- a/lib/registrar.ts
+++ b/lib/registrar.ts
@@ -1,5 +1,5 @@
-import type * as types from "./types";
 import type { DNSimple, QueryParams } from "./main";
+import type * as types from "./types";
 
 export class Registrar {
   constructor(private readonly _client: DNSimple) {}

--- a/lib/registrar.ts
+++ b/lib/registrar.ts
@@ -1,3 +1,4 @@
+import type * as types from "./types";
 import type { DNSimple, QueryParams } from "./main";
 
 export class Registrar {
@@ -19,9 +20,7 @@ export class Registrar {
       account: number,
       domain: string,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: { domain: string; available: boolean; premium: boolean };
-    }> =>
+    ): Promise<{ data: types.DomainCheckResult }> =>
       this._client.request(
         "GET",
         `/${account}/registrar/domains/${domain}/check`,
@@ -52,7 +51,7 @@ export class Registrar {
       account: number,
       domain: string,
       params: QueryParams & { action?: string } = {}
-    ): Promise<{ data: { premium_price: string; action: string } }> =>
+    ): Promise<{ data: types.DomainPremiumPrice }> =>
       this._client.request(
         "GET",
         `/${account}/registrar/domains/${domain}/premium_price`,
@@ -78,15 +77,7 @@ export class Registrar {
       account: number,
       domain: string,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        domain: string;
-        premium: boolean;
-        registration_price: number;
-        renewal_price: number;
-        transfer_price: number;
-      };
-    }> =>
+    ): Promise<{ data: types.DomainPrices }> =>
       this._client.request(
         "GET",
         `/${account}/registrar/domains/${domain}/prices`,
@@ -113,27 +104,15 @@ export class Registrar {
     const method = (
       account: number,
       domain: string,
-      data: {
-        registrant_id?: number;
-        whois_privacy?: boolean;
-        auto_renew?: boolean;
-        extended_attributes?: {};
-        premium_price?: string;
-      },
-      params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        domain_id: number;
+      data: Partial<{
         registrant_id: number;
-        period: number;
-        state: string;
-        auto_renew: boolean;
         whois_privacy: boolean;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+        auto_renew: boolean;
+        extended_attributes: {};
+        premium_price: string;
+      }>,
+      params: QueryParams & {} = {}
+    ): Promise<{ data: types.DomainRegistration }> =>
       this._client.request(
         "POST",
         `/${account}/registrar/domains/${domain}/registrations`,
@@ -161,19 +140,7 @@ export class Registrar {
       domain: string,
       domainregistration: number,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        domain_id: number;
-        registrant_id: number;
-        period: number;
-        state: string;
-        auto_renew: boolean;
-        whois_privacy: boolean;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+    ): Promise<{ data: types.DomainRegistration }> =>
       this._client.request(
         "GET",
         `/${account}/registrar/domains/${domain}/registrations/${domainregistration}`,
@@ -200,28 +167,16 @@ export class Registrar {
     const method = (
       account: number,
       domain: string,
-      data: {
-        registrant_id?: number;
-        auth_code?: string;
-        whois_privacy?: boolean;
-        auto_renew?: boolean;
-        extended_attributes?: {};
-        premium_price?: string;
-      },
-      params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        domain_id: number;
+      data: Partial<{
         registrant_id: number;
-        state: string;
-        auto_renew: boolean;
+        auth_code: string;
         whois_privacy: boolean;
-        status_description: string;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+        auto_renew: boolean;
+        extended_attributes: {};
+        premium_price: string;
+      }>,
+      params: QueryParams & {} = {}
+    ): Promise<{ data: types.DomainTransfer }> =>
       this._client.request(
         "POST",
         `/${account}/registrar/domains/${domain}/transfers`,
@@ -249,19 +204,7 @@ export class Registrar {
       domain: string,
       domaintransfer: number,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        domain_id: number;
-        registrant_id: number;
-        state: string;
-        auto_renew: boolean;
-        whois_privacy: boolean;
-        status_description: string;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+    ): Promise<{ data: types.DomainTransfer }> =>
       this._client.request(
         "GET",
         `/${account}/registrar/domains/${domain}/transfers/${domaintransfer}`,
@@ -289,19 +232,7 @@ export class Registrar {
       domain: string,
       domaintransfer: number,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        domain_id: number;
-        registrant_id: number;
-        state: string;
-        auto_renew: boolean;
-        whois_privacy: boolean;
-        status_description: string;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+    ): Promise<{ data: types.DomainTransfer }> =>
       this._client.request(
         "DELETE",
         `/${account}/registrar/domains/${domain}/transfers/${domaintransfer}`,
@@ -328,18 +259,9 @@ export class Registrar {
     const method = (
       account: number,
       domain: string,
-      data: { period?: number; premium_price?: string },
+      data: Partial<{ period: number; premium_price: string }>,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        domain_id: number;
-        period: number;
-        state: string;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+    ): Promise<{ data: types.DomainRenewal }> =>
       this._client.request(
         "POST",
         `/${account}/registrar/domains/${domain}/renewals`,
@@ -367,16 +289,7 @@ export class Registrar {
       domain: string,
       domainrenewal: number,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        domain_id: number;
-        period: number;
-        state: string;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+    ): Promise<{ data: types.DomainRenewal }> =>
       this._client.request(
         "GET",
         `/${account}/registrar/domains/${domain}/renewals/${domainrenewal}`,
@@ -455,7 +368,7 @@ export class Registrar {
     const method = (
       account: number,
       domain: string,
-      data: Array<string>,
+      data: Partial<Array<string>>,
       params: QueryParams & {} = {}
     ): Promise<{ data: Array<string> }> =>
       this._client.request(
@@ -482,18 +395,9 @@ export class Registrar {
     const method = (
       account: number,
       domain: string,
-      data: Array<string>,
+      data: Partial<Array<string>>,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: Array<{
-        id: number;
-        name: string;
-        ipv4: string;
-        ipv6: string;
-        created_at: string;
-        updated_at: string;
-      }>;
-    }> =>
+    ): Promise<{ data: Array<types.NameServer> }> =>
       this._client.request(
         "PUT",
         `/${account}/registrar/domains/${domain}/delegation/vanity`,
@@ -597,16 +501,7 @@ export class Registrar {
       account: number,
       domain: string,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        domain_id: number;
-        enabled: boolean;
-        expires_on: string;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+    ): Promise<{ data: types.WhoisPrivacy }> =>
       this._client.request(
         "GET",
         `/${account}/registrar/domains/${domain}/whois_privacy`,
@@ -634,16 +529,7 @@ export class Registrar {
       account: number,
       domain: string,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        domain_id: number;
-        enabled: boolean;
-        expires_on: string;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+    ): Promise<{ data: types.WhoisPrivacy }> =>
       this._client.request(
         "PUT",
         `/${account}/registrar/domains/${domain}/whois_privacy`,
@@ -669,16 +555,7 @@ export class Registrar {
       account: number,
       domain: string,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        domain_id: number;
-        enabled: boolean;
-        expires_on: string;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+    ): Promise<{ data: types.WhoisPrivacy }> =>
       this._client.request(
         "DELETE",
         `/${account}/registrar/domains/${domain}/whois_privacy`,
@@ -706,18 +583,7 @@ export class Registrar {
       account: number,
       domain: string,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        domain_id: number;
-        whois_privacy_id: number;
-        state: string;
-        enabled: boolean;
-        expires_on: string;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+    ): Promise<{ data: types.WhoisPrivacyRenewal }> =>
       this._client.request(
         "POST",
         `/${account}/registrar/domains/${domain}/whois_privacy/renewals`,

--- a/lib/secondary_dns.ts
+++ b/lib/secondary_dns.ts
@@ -1,3 +1,4 @@
+import type * as types from "./types";
 import type { DNSimple, QueryParams } from "./main";
 import { paginate } from "./paginate";
 
@@ -22,22 +23,8 @@ export class SecondaryDns {
       account: number,
       params: QueryParams & { sort?: string } = {}
     ): Promise<{
-      data: Array<{
-        id: number;
-        account_id: number;
-        name: string;
-        ip: string;
-        port: number;
-        linked_secondary_zones: Array<string>;
-        created_at: string;
-        updated_at: string;
-      }>;
-      pagination: {
-        current_page: number;
-        per_page: number;
-        total_entries: number;
-        total_pages: number;
-      };
+      data: Array<types.PrimaryServer>;
+      pagination: types.Pagination;
     }> =>
       this._client.request(
         "GET",
@@ -75,20 +62,9 @@ export class SecondaryDns {
   createPrimaryServer = (() => {
     const method = (
       account: number,
-      data: { name?: string; ip?: string; port?: string },
+      data: Partial<{ name: string; ip: string; port: string }>,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        account_id: number;
-        name: string;
-        ip: string;
-        port: number;
-        linked_secondary_zones: Array<string>;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+    ): Promise<{ data: types.PrimaryServer }> =>
       this._client.request(
         "POST",
         `/${account}/secondary_dns/primaries`,
@@ -114,18 +90,7 @@ export class SecondaryDns {
       account: number,
       primaryserver: number,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        account_id: number;
-        name: string;
-        ip: string;
-        port: number;
-        linked_secondary_zones: Array<string>;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+    ): Promise<{ data: types.PrimaryServer }> =>
       this._client.request(
         "GET",
         `/${account}/secondary_dns/primaries/${primaryserver}`,
@@ -177,18 +142,7 @@ export class SecondaryDns {
       account: number,
       primaryserver: number,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        account_id: number;
-        name: string;
-        ip: string;
-        port: number;
-        linked_secondary_zones: Array<string>;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+    ): Promise<{ data: types.PrimaryServer }> =>
       this._client.request(
         "PUT",
         `/${account}/secondary_dns/primaries/${primaryserver}/link`,
@@ -214,18 +168,7 @@ export class SecondaryDns {
       account: number,
       primaryserver: number,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        account_id: number;
-        name: string;
-        ip: string;
-        port: number;
-        linked_secondary_zones: Array<string>;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+    ): Promise<{ data: types.PrimaryServer }> =>
       this._client.request(
         "PUT",
         `/${account}/secondary_dns/primaries/${primaryserver}/unlink`,
@@ -248,20 +191,9 @@ export class SecondaryDns {
   createSecondaryZone = (() => {
     const method = (
       account: number,
-      data: { name?: string },
+      data: Partial<{ name: string }>,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        account_id: number;
-        name: string;
-        reverse: boolean;
-        secondary: boolean;
-        last_transferred_at: string;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+    ): Promise<{ data: types.Zone }> =>
       this._client.request(
         "POST",
         `/${account}/secondary_dns/zones`,

--- a/lib/secondary_dns.ts
+++ b/lib/secondary_dns.ts
@@ -1,6 +1,6 @@
-import type * as types from "./types";
 import type { DNSimple, QueryParams } from "./main";
 import { paginate } from "./paginate";
+import type * as types from "./types";
 
 export class SecondaryDns {
   constructor(private readonly _client: DNSimple) {}
@@ -21,7 +21,9 @@ export class SecondaryDns {
   listPrimaryServers = (() => {
     const method = (
       account: number,
-      params: QueryParams & { sort?: string } = {}
+      params: QueryParams & {
+        sort?: "id:asc" | "id:desc" | "name:asc" | "name:desc";
+      } = {}
     ): Promise<{
       data: Array<types.PrimaryServer>;
       pagination: types.Pagination;
@@ -34,11 +36,15 @@ export class SecondaryDns {
       );
     method.iterateAll = (
       account: number,
-      params: QueryParams & { sort?: string } = {}
+      params: QueryParams & {
+        sort?: "id:asc" | "id:desc" | "name:asc" | "name:desc";
+      } = {}
     ) => paginate((page) => method(account, { ...params, page } as any));
     method.collectAll = async (
       account: number,
-      params: QueryParams & { sort?: string } = {}
+      params: QueryParams & {
+        sort?: "id:asc" | "id:desc" | "name:asc" | "name:desc";
+      } = {}
     ) => {
       const items = [];
       for await (const item of method.iterateAll(account, params)) {

--- a/lib/services.ts
+++ b/lib/services.ts
@@ -1,6 +1,6 @@
-import type * as types from "./types";
 import type { DNSimple, QueryParams } from "./main";
 import { paginate } from "./paginate";
+import type * as types from "./types";
 
 export class Services {
   constructor(private readonly _client: DNSimple) {}
@@ -19,13 +19,20 @@ export class Services {
    */
   listServices = (() => {
     const method = (
-      params: QueryParams & { sort?: string } = {}
+      params: QueryParams & {
+        sort?: "id:asc" | "id:desc" | "sid:asc" | "sid:desc";
+      } = {}
     ): Promise<{ data: Array<types.Service>; pagination: types.Pagination }> =>
       this._client.request("GET", `/services`, null, params);
-    method.iterateAll = (params: QueryParams & { sort?: string } = {}) =>
-      paginate((page) => method({ ...params, page } as any));
+    method.iterateAll = (
+      params: QueryParams & {
+        sort?: "id:asc" | "id:desc" | "sid:asc" | "sid:desc";
+      } = {}
+    ) => paginate((page) => method({ ...params, page } as any));
     method.collectAll = async (
-      params: QueryParams & { sort?: string } = {}
+      params: QueryParams & {
+        sort?: "id:asc" | "id:desc" | "sid:asc" | "sid:desc";
+      } = {}
     ) => {
       const items = [];
       for await (const item of method.iterateAll(params)) {

--- a/lib/services.ts
+++ b/lib/services.ts
@@ -1,3 +1,4 @@
+import type * as types from "./types";
 import type { DNSimple, QueryParams } from "./main";
 import { paginate } from "./paginate";
 
@@ -19,33 +20,8 @@ export class Services {
   listServices = (() => {
     const method = (
       params: QueryParams & { sort?: string } = {}
-    ): Promise<{
-      data: Array<{
-        id: number;
-        name: string;
-        sid: string;
-        description: string;
-        setup_description: string | null;
-        requires_setup: boolean;
-        default_subdomain: string | null;
-        created_at: string;
-        updated_at: string;
-        settings: Array<{
-          name: string;
-          label: string;
-          append: string;
-          description: string;
-          example: string;
-          password?: boolean;
-        }>;
-      }>;
-      pagination: {
-        current_page: number;
-        per_page: number;
-        total_entries: number;
-        total_pages: number;
-      };
-    }> => this._client.request("GET", `/services`, null, params);
+    ): Promise<{ data: Array<types.Service>; pagination: types.Pagination }> =>
+      this._client.request("GET", `/services`, null, params);
     method.iterateAll = (params: QueryParams & { sort?: string } = {}) =>
       paginate((page) => method({ ...params, page } as any));
     method.collectAll = async (
@@ -74,27 +50,8 @@ export class Services {
     const method = (
       service: string,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        name: string;
-        sid: string;
-        description: string;
-        setup_description: string | null;
-        requires_setup: boolean;
-        default_subdomain: string | null;
-        created_at: string;
-        updated_at: string;
-        settings: Array<{
-          name: string;
-          label: string;
-          append: string;
-          description: string;
-          example: string;
-          password?: boolean;
-        }>;
-      };
-    }> => this._client.request("GET", `/services/${service}`, null, params);
+    ): Promise<{ data: types.Service }> =>
+      this._client.request("GET", `/services/${service}`, null, params);
     return method;
   })();
 
@@ -116,33 +73,7 @@ export class Services {
       account: number,
       domain: string,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: Array<{
-        id: number;
-        name: string;
-        sid: string;
-        description: string;
-        setup_description: string | null;
-        requires_setup: boolean;
-        default_subdomain: string | null;
-        created_at: string;
-        updated_at: string;
-        settings: Array<{
-          name: string;
-          label: string;
-          append: string;
-          description: string;
-          example: string;
-          password?: boolean;
-        }>;
-      }>;
-      pagination: {
-        current_page: number;
-        per_page: number;
-        total_entries: number;
-        total_pages: number;
-      };
-    }> =>
+    ): Promise<{ data: Array<types.Service>; pagination: types.Pagination }> =>
       this._client.request(
         "GET",
         `/${account}/domains/${domain}/services`,
@@ -186,7 +117,7 @@ export class Services {
       account: number,
       domain: string,
       service: string,
-      data: {},
+      data: Partial<{}>,
       params: QueryParams & {} = {}
     ): Promise<{}> =>
       this._client.request(

--- a/lib/templates.ts
+++ b/lib/templates.ts
@@ -1,6 +1,6 @@
-import type * as types from "./types";
 import type { DNSimple, QueryParams } from "./main";
 import { paginate } from "./paginate";
+import type * as types from "./types";
 
 export class Templates {
   constructor(private readonly _client: DNSimple) {}
@@ -21,16 +21,40 @@ export class Templates {
   listTemplates = (() => {
     const method = (
       account: number,
-      params: QueryParams & { sort?: string } = {}
+      params: QueryParams & {
+        sort?:
+          | "id:asc"
+          | "id:desc"
+          | "name:asc"
+          | "name:desc"
+          | "sid:asc"
+          | "sid:desc";
+      } = {}
     ): Promise<{ data: Array<types.Template>; pagination: types.Pagination }> =>
       this._client.request("GET", `/${account}/templates`, null, params);
     method.iterateAll = (
       account: number,
-      params: QueryParams & { sort?: string } = {}
+      params: QueryParams & {
+        sort?:
+          | "id:asc"
+          | "id:desc"
+          | "name:asc"
+          | "name:desc"
+          | "sid:asc"
+          | "sid:desc";
+      } = {}
     ) => paginate((page) => method(account, { ...params, page } as any));
     method.collectAll = async (
       account: number,
-      params: QueryParams & { sort?: string } = {}
+      params: QueryParams & {
+        sort?:
+          | "id:asc"
+          | "id:desc"
+          | "name:asc"
+          | "name:desc"
+          | "sid:asc"
+          | "sid:desc";
+      } = {}
     ) => {
       const items = [];
       for await (const item of method.iterateAll(account, params)) {
@@ -158,7 +182,17 @@ export class Templates {
     const method = (
       account: number,
       template: number | string,
-      params: QueryParams & { sort?: string } = {}
+      params: QueryParams & {
+        sort?:
+          | "id:asc"
+          | "id:desc"
+          | "name:asc"
+          | "name:desc"
+          | "content:asc"
+          | "content:desc"
+          | "type:asc"
+          | "type:desc";
+      } = {}
     ): Promise<{
       data: Array<types.TemplateRecord>;
       pagination: types.Pagination;
@@ -172,13 +206,33 @@ export class Templates {
     method.iterateAll = (
       account: number,
       template: number | string,
-      params: QueryParams & { sort?: string } = {}
+      params: QueryParams & {
+        sort?:
+          | "id:asc"
+          | "id:desc"
+          | "name:asc"
+          | "name:desc"
+          | "content:asc"
+          | "content:desc"
+          | "type:asc"
+          | "type:desc";
+      } = {}
     ) =>
       paginate((page) => method(account, template, { ...params, page } as any));
     method.collectAll = async (
       account: number,
       template: number | string,
-      params: QueryParams & { sort?: string } = {}
+      params: QueryParams & {
+        sort?:
+          | "id:asc"
+          | "id:desc"
+          | "name:asc"
+          | "name:desc"
+          | "content:asc"
+          | "content:desc"
+          | "type:asc"
+          | "type:desc";
+      } = {}
     ) => {
       const items = [];
       for await (const item of method.iterateAll(account, template, params)) {

--- a/lib/templates.ts
+++ b/lib/templates.ts
@@ -1,3 +1,4 @@
+import type * as types from "./types";
 import type { DNSimple, QueryParams } from "./main";
 import { paginate } from "./paginate";
 
@@ -21,23 +22,8 @@ export class Templates {
     const method = (
       account: number,
       params: QueryParams & { sort?: string } = {}
-    ): Promise<{
-      data: Array<{
-        id: number;
-        account_id: number;
-        name: string;
-        sid: string;
-        description: string;
-        created_at: string;
-        updated_at: string;
-      }>;
-      pagination: {
-        current_page: number;
-        per_page: number;
-        total_entries: number;
-        total_pages: number;
-      };
-    }> => this._client.request("GET", `/${account}/templates`, null, params);
+    ): Promise<{ data: Array<types.Template>; pagination: types.Pagination }> =>
+      this._client.request("GET", `/${account}/templates`, null, params);
     method.iterateAll = (
       account: number,
       params: QueryParams & { sort?: string } = {}
@@ -68,19 +54,10 @@ export class Templates {
   createTemplate = (() => {
     const method = (
       account: number,
-      data: { sid?: string; name?: string; description?: string },
+      data: Partial<{ sid: string; name: string; description: string }>,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        account_id: number;
-        name: string;
-        sid: string;
-        description: string;
-        created_at: string;
-        updated_at: string;
-      };
-    }> => this._client.request("POST", `/${account}/templates`, data, params);
+    ): Promise<{ data: types.Template }> =>
+      this._client.request("POST", `/${account}/templates`, data, params);
     return method;
   })();
 
@@ -100,17 +77,7 @@ export class Templates {
       account: number,
       template: number | string,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        account_id: number;
-        name: string;
-        sid: string;
-        description: string;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+    ): Promise<{ data: types.Template }> =>
       this._client.request(
         "GET",
         `/${account}/templates/${template}`,
@@ -135,19 +102,9 @@ export class Templates {
     const method = (
       account: number,
       template: number | string,
-      data: { sid?: string; name?: string; description?: string },
+      data: Partial<{ sid: string; name: string; description: string }>,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        account_id: number;
-        name: string;
-        sid: string;
-        description: string;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+    ): Promise<{ data: types.Template }> =>
       this._client.request(
         "PATCH",
         `/${account}/templates/${template}`,
@@ -203,23 +160,8 @@ export class Templates {
       template: number | string,
       params: QueryParams & { sort?: string } = {}
     ): Promise<{
-      data: Array<{
-        id: number;
-        template_id: number;
-        name: string;
-        content: string;
-        ttl: number;
-        priority: number | null;
-        type: string;
-        created_at: string;
-        updated_at: string;
-      }>;
-      pagination: {
-        current_page: number;
-        per_page: number;
-        total_entries: number;
-        total_pages: number;
-      };
+      data: Array<types.TemplateRecord>;
+      pagination: types.Pagination;
     }> =>
       this._client.request(
         "GET",
@@ -262,21 +204,9 @@ export class Templates {
     const method = (
       account: number,
       template: number | string,
-      data: {},
+      data: Partial<{}>,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        template_id: number;
-        name: string;
-        content: string;
-        ttl: number;
-        priority: number | null;
-        type: string;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+    ): Promise<{ data: types.TemplateRecord }> =>
       this._client.request(
         "POST",
         `/${account}/templates/${template}/records`,
@@ -304,19 +234,7 @@ export class Templates {
       template: number | string,
       templaterecord: number,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        template_id: number;
-        name: string;
-        content: string;
-        ttl: number;
-        priority: number | null;
-        type: string;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+    ): Promise<{ data: types.TemplateRecord }> =>
       this._client.request(
         "GET",
         `/${account}/templates/${template}/records/${templaterecord}`,

--- a/lib/tlds.ts
+++ b/lib/tlds.ts
@@ -1,6 +1,6 @@
-import type * as types from "./types";
 import type { DNSimple, QueryParams } from "./main";
 import { paginate } from "./paginate";
+import type * as types from "./types";
 
 export class Tlds {
   constructor(private readonly _client: DNSimple) {}
@@ -19,13 +19,14 @@ export class Tlds {
    */
   listTlds = (() => {
     const method = (
-      params: QueryParams & { sort?: string } = {}
+      params: QueryParams & { sort?: "tld:asc" | "tld:desc" } = {}
     ): Promise<{ data: Array<types.TLD>; pagination: types.Pagination }> =>
       this._client.request("GET", `/tlds`, null, params);
-    method.iterateAll = (params: QueryParams & { sort?: string } = {}) =>
-      paginate((page) => method({ ...params, page } as any));
+    method.iterateAll = (
+      params: QueryParams & { sort?: "tld:asc" | "tld:desc" } = {}
+    ) => paginate((page) => method({ ...params, page } as any));
     method.collectAll = async (
-      params: QueryParams & { sort?: string } = {}
+      params: QueryParams & { sort?: "tld:asc" | "tld:desc" } = {}
     ) => {
       const items = [];
       for await (const item of method.iterateAll(params)) {

--- a/lib/tlds.ts
+++ b/lib/tlds.ts
@@ -1,3 +1,4 @@
+import type * as types from "./types";
 import type { DNSimple, QueryParams } from "./main";
 import { paginate } from "./paginate";
 
@@ -19,26 +20,8 @@ export class Tlds {
   listTlds = (() => {
     const method = (
       params: QueryParams & { sort?: string } = {}
-    ): Promise<{
-      data: Array<{
-        tld: string;
-        tld_type: number;
-        whois_privacy: boolean;
-        auto_renew_only: boolean;
-        idn: boolean;
-        minimum_registration: number;
-        registration_enabled: boolean;
-        renewal_enabled: boolean;
-        transfer_enabled: boolean;
-        dnssec_interface_type: string;
-      }>;
-      pagination: {
-        current_page: number;
-        per_page: number;
-        total_entries: number;
-        total_pages: number;
-      };
-    }> => this._client.request("GET", `/tlds`, null, params);
+    ): Promise<{ data: Array<types.TLD>; pagination: types.Pagination }> =>
+      this._client.request("GET", `/tlds`, null, params);
     method.iterateAll = (params: QueryParams & { sort?: string } = {}) =>
       paginate((page) => method({ ...params, page } as any));
     method.collectAll = async (
@@ -67,20 +50,8 @@ export class Tlds {
     const method = (
       tld: string,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        tld: string;
-        tld_type: number;
-        whois_privacy: boolean;
-        auto_renew_only: boolean;
-        idn: boolean;
-        minimum_registration: number;
-        registration_enabled: boolean;
-        renewal_enabled: boolean;
-        transfer_enabled: boolean;
-        dnssec_interface_type: string;
-      };
-    }> => this._client.request("GET", `/tlds/${tld}`, null, params);
+    ): Promise<{ data: types.TLD }> =>
+      this._client.request("GET", `/tlds/${tld}`, null, params);
     return method;
   })();
 
@@ -100,14 +71,7 @@ export class Tlds {
     const method = (
       tld: string,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: Array<{
-        name: string;
-        description: string;
-        required: boolean;
-        options: Array<{ title: string; value: string; description: string }>;
-      }>;
-    }> =>
+    ): Promise<{ data: Array<types.ExtendedAttribute> }> =>
       this._client.request(
         "GET",
         `/tlds/${tld}/extended_attributes`,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -21,7 +21,7 @@ export type Domain = {
   registrant_id: number | null;
   name: string;
   unicode_name: string;
-  state: string;
+  state: "hosted" | "registered" | "expired";
   auto_renew: boolean;
   private_whois: boolean;
   expires_at: NullableDateTime;
@@ -96,10 +96,20 @@ export type Certificate = {
   common_name: string;
   years: number;
   csr: string;
-  state: string;
+  state:
+    | "new"
+    | "purchased"
+    | "configured"
+    | "submitted"
+    | "issued"
+    | "rejected"
+    | "refunded"
+    | "cancelled"
+    | "requesting"
+    | "failed";
   auto_renew: boolean;
   alternate_names: Array<string>;
-  authority_identifier: string;
+  authority_identifier: "comodo" | "rapidssl" | "letsencrypt";
   created_at: string;
   updated_at: string;
   expires_at: string;
@@ -117,7 +127,17 @@ export type CertificatePrivateKey = { private_key: string };
 export type LetsencryptCertificatePurchase = {
   id: number;
   certificate_id: number;
-  state: string;
+  state:
+    | "new"
+    | "purchased"
+    | "configured"
+    | "submitted"
+    | "issued"
+    | "rejected"
+    | "refunded"
+    | "cancelled"
+    | "requesting"
+    | "failed";
   auto_renew: boolean;
   created_at: string;
   updated_at: string;
@@ -127,15 +147,17 @@ export type LetsencryptCertificateRenewal = {
   id: number;
   old_certificate_id: number;
   new_certificate_id: number;
-  state: string;
+  state: "cancelled" | "new" | "renewing" | "renewed" | "failed";
   auto_renew: boolean;
   created_at: string;
   updated_at: string;
 };
 
+export type TLDType = 1 | 2 | 3;
+
 export type TLD = {
   tld: string;
-  tld_type: number;
+  tld_type: TLDType;
   whois_privacy: boolean;
   auto_renew_only: boolean;
   idn: boolean;
@@ -143,7 +165,7 @@ export type TLD = {
   registration_enabled: boolean;
   renewal_enabled: boolean;
   transfer_enabled: boolean;
-  dnssec_interface_type: string;
+  dnssec_interface_type: "ds" | "key";
 };
 
 export type ExtendedAttributeOption = {
@@ -180,7 +202,7 @@ export type DomainRegistration = {
   domain_id: number;
   registrant_id: number;
   period: number;
-  state: string;
+  state: "cancelled" | "new" | "registering" | "registered" | "failed";
   auto_renew: boolean;
   whois_privacy: boolean;
   created_at: string;
@@ -191,7 +213,7 @@ export type DomainTransfer = {
   id: number;
   domain_id: number;
   registrant_id: number;
-  state: string;
+  state: "cancelled" | "new" | "transferring" | "transferred" | "failed";
   auto_renew: boolean;
   whois_privacy: boolean;
   status_description: string;
@@ -203,7 +225,7 @@ export type DomainRenewal = {
   id: number;
   domain_id: number;
   period: number;
-  state: string;
+  state: "cancelled" | "new" | "renewing" | "renewed" | "failed";
   created_at: string;
   updated_at: string;
 };
@@ -263,6 +285,38 @@ export type ZoneFile = { zone: string };
 
 export type ZoneDistribution = { distributed: boolean };
 
+export type ZoneRecordType =
+  | "A"
+  | "AAAA"
+  | "ALIAS"
+  | "CAA"
+  | "CNAME"
+  | "DNSKEY"
+  | "DS"
+  | "HINFO"
+  | "MX"
+  | "NAPTR"
+  | "NS"
+  | "POOL"
+  | "PTR"
+  | "SOA"
+  | "SPF"
+  | "SRV"
+  | "SSHFP"
+  | "TXT"
+  | "URL";
+
+export type ZoneRecordRegion =
+  | "global"
+  | "SV1"
+  | "ORD"
+  | "IAD"
+  | "AMS"
+  | "TKO"
+  | "SYD"
+  | "CDG"
+  | "FRA";
+
 export type ZoneRecord = {
   id: number;
   zone_id: string;
@@ -271,8 +325,8 @@ export type ZoneRecord = {
   content: string;
   ttl: number;
   priority?: number | null;
-  type: string;
-  regions: Array<string>;
+  type: ZoneRecordType;
+  regions: Array<ZoneRecordRegion>;
   system_record: boolean;
   created_at: string;
   updated_at: string;
@@ -331,6 +385,27 @@ export type Template = {
   updated_at: string;
 };
 
+export type TemplateRecordType =
+  | "A"
+  | "AAAA"
+  | "ALIAS"
+  | "CAA"
+  | "CNAME"
+  | "DNSKEY"
+  | "DS"
+  | "HINFO"
+  | "MX"
+  | "NAPTR"
+  | "NS"
+  | "POOL"
+  | "PTR"
+  | "SOA"
+  | "SPF"
+  | "SRV"
+  | "SSHFP"
+  | "TXT"
+  | "URL";
+
 export type TemplateRecord = {
   id: number;
   template_id: number;
@@ -338,7 +413,7 @@ export type TemplateRecord = {
   content: string;
   ttl: number;
   priority: number | null;
-  type: string;
+  type: TemplateRecordType;
   created_at: string;
   updated_at: string;
 };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,355 @@
+export type Account = {
+  id: number;
+  email: string;
+  plan_identifier: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type User = {
+  id: number;
+  email: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type NullableDateTime = string | null;
+
+export type Domain = {
+  id: number;
+  account_id: number;
+  registrant_id: number | null;
+  name: string;
+  unicode_name: string;
+  state: string;
+  auto_renew: boolean;
+  private_whois: boolean;
+  expires_at: NullableDateTime;
+  expires_on: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type Pagination = {
+  current_page: number;
+  per_page: number;
+  total_entries: number;
+  total_pages: number;
+};
+
+export type Collaborator = {
+  id: number;
+  domain_id: number;
+  domain_name: string;
+  user_id: number;
+  user_email: string;
+  invitation: boolean;
+  created_at: string;
+  updated_at: string;
+  accepted_at: string;
+};
+
+export type DNSSEC = {
+  enabled: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+export type DelegationSigner = {
+  id: number;
+  domain_id: number;
+  algorithm: string;
+  digest: string;
+  digest_type: string;
+  keytag: string;
+  public_key: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type EmailForward = {
+  id: number;
+  domain_id: number;
+  alias_email: string;
+  destination_email: string;
+  from: string;
+  to: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type Push = {
+  id: number;
+  domain_id: number;
+  contact_id: number;
+  account_id: number;
+  created_at: string;
+  updated_at: string;
+  accepted_at: NullableDateTime;
+};
+
+export type Certificate = {
+  id: number;
+  domain_id: number;
+  contact_id: number;
+  name: string;
+  common_name: string;
+  years: number;
+  csr: string;
+  state: string;
+  auto_renew: boolean;
+  alternate_names: Array<string>;
+  authority_identifier: string;
+  created_at: string;
+  updated_at: string;
+  expires_at: string;
+  expires_on: string;
+};
+
+export type CertificateDownload = {
+  server: string;
+  root: string | null;
+  chain: Array<string>;
+};
+
+export type CertificatePrivateKey = { private_key: string };
+
+export type LetsencryptCertificatePurchase = {
+  id: number;
+  certificate_id: number;
+  state: string;
+  auto_renew: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+export type LetsencryptCertificateRenewal = {
+  id: number;
+  old_certificate_id: number;
+  new_certificate_id: number;
+  state: string;
+  auto_renew: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+export type TLD = {
+  tld: string;
+  tld_type: number;
+  whois_privacy: boolean;
+  auto_renew_only: boolean;
+  idn: boolean;
+  minimum_registration: number;
+  registration_enabled: boolean;
+  renewal_enabled: boolean;
+  transfer_enabled: boolean;
+  dnssec_interface_type: string;
+};
+
+export type ExtendedAttributeOption = {
+  title: string;
+  value: string;
+  description: string;
+};
+
+export type ExtendedAttribute = {
+  name: string;
+  description: string;
+  required: boolean;
+  options: Array<ExtendedAttributeOption>;
+};
+
+export type DomainCheckResult = {
+  domain: string;
+  available: boolean;
+  premium: boolean;
+};
+
+export type DomainPremiumPrice = { premium_price: string; action: string };
+
+export type DomainPrices = {
+  domain: string;
+  premium: boolean;
+  registration_price: number;
+  renewal_price: number;
+  transfer_price: number;
+};
+
+export type DomainRegistration = {
+  id: number;
+  domain_id: number;
+  registrant_id: number;
+  period: number;
+  state: string;
+  auto_renew: boolean;
+  whois_privacy: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+export type DomainTransfer = {
+  id: number;
+  domain_id: number;
+  registrant_id: number;
+  state: string;
+  auto_renew: boolean;
+  whois_privacy: boolean;
+  status_description: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type DomainRenewal = {
+  id: number;
+  domain_id: number;
+  period: number;
+  state: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type NameServer = {
+  id: number;
+  name: string;
+  ipv4: string;
+  ipv6: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type WhoisPrivacy = {
+  id: number;
+  domain_id: number;
+  enabled: boolean;
+  expires_on: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type WhoisPrivacyRenewal = {
+  id: number;
+  domain_id: number;
+  whois_privacy_id: number;
+  state: string;
+  enabled: boolean;
+  expires_on: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type PrimaryServer = {
+  id: number;
+  account_id: number;
+  name: string;
+  ip: string;
+  port: number;
+  linked_secondary_zones: Array<string>;
+  created_at: string;
+  updated_at: string;
+};
+
+export type Zone = {
+  id: number;
+  account_id: number;
+  name: string;
+  reverse: boolean;
+  secondary: boolean;
+  last_transferred_at: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ZoneFile = { zone: string };
+
+export type ZoneDistribution = { distributed: boolean };
+
+export type ZoneRecord = {
+  id: number;
+  zone_id: string;
+  parent_id: number | null;
+  name: string;
+  content: string;
+  ttl: number;
+  priority?: number | null;
+  type: string;
+  regions: Array<string>;
+  system_record: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+export type Contact = {
+  id: number;
+  account_id: number;
+  label: string;
+  first_name: string;
+  last_name: string;
+  organization_name: string;
+  job_title: string;
+  address1: string;
+  address2: string;
+  city: string;
+  state_province: string;
+  postal_code: string;
+  country: string;
+  phone: string;
+  fax: string;
+  email: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ServiceSetting = {
+  name: string;
+  label: string;
+  append: string;
+  description: string;
+  example: string;
+  password?: boolean;
+};
+
+export type Service = {
+  id: number;
+  name: string;
+  sid: string;
+  description: string;
+  setup_description: string | null;
+  requires_setup: boolean;
+  default_subdomain: string | null;
+  created_at: string;
+  updated_at: string;
+  settings: Array<ServiceSetting>;
+};
+
+export type Template = {
+  id: number;
+  account_id: number;
+  name: string;
+  sid: string;
+  description: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type TemplateRecord = {
+  id: number;
+  template_id: number;
+  name: string;
+  content: string;
+  ttl: number;
+  priority: number | null;
+  type: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type VanityNameServer = {
+  id: number;
+  name: string;
+  ipv4: string;
+  ipv6: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type Webhook = { id: number; url: string; suppressed_at: string };

--- a/lib/vanity_name_servers.ts
+++ b/lib/vanity_name_servers.ts
@@ -1,3 +1,4 @@
+import type * as types from "./types";
 import type { DNSimple, QueryParams } from "./main";
 
 export class VanityNameServers {
@@ -21,16 +22,7 @@ export class VanityNameServers {
       account: number,
       domain: string,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: Array<{
-        id: number;
-        name: string;
-        ipv4: string;
-        ipv6: string;
-        created_at: string;
-        updated_at: string;
-      }>;
-    }> =>
+    ): Promise<{ data: Array<types.VanityNameServer> }> =>
       this._client.request("PUT", `/${account}/vanity/${domain}`, null, params);
     return method;
   })();

--- a/lib/vanity_name_servers.ts
+++ b/lib/vanity_name_servers.ts
@@ -1,5 +1,5 @@
-import type * as types from "./types";
 import type { DNSimple, QueryParams } from "./main";
+import type * as types from "./types";
 
 export class VanityNameServers {
   constructor(private readonly _client: DNSimple) {}

--- a/lib/webhooks.ts
+++ b/lib/webhooks.ts
@@ -1,3 +1,4 @@
+import type * as types from "./types";
 import type { DNSimple, QueryParams } from "./main";
 
 export class Webhooks {
@@ -18,9 +19,8 @@ export class Webhooks {
     const method = (
       account: number,
       params: QueryParams & { sort?: string } = {}
-    ): Promise<{
-      data: Array<{ id: number; url: string; suppressed_at: string }>;
-    }> => this._client.request("GET", `/${account}/webhooks`, null, params);
+    ): Promise<{ data: Array<types.Webhook> }> =>
+      this._client.request("GET", `/${account}/webhooks`, null, params);
     return method;
   })();
 
@@ -37,9 +37,9 @@ export class Webhooks {
   createWebhook = (() => {
     const method = (
       account: number,
-      data: { url?: string },
+      data: Partial<{ url: string }>,
       params: QueryParams & {} = {}
-    ): Promise<{ data: { id: number; url: string; suppressed_at: string } }> =>
+    ): Promise<{ data: types.Webhook }> =>
       this._client.request("POST", `/${account}/webhooks`, data, params);
     return method;
   })();
@@ -60,7 +60,7 @@ export class Webhooks {
       account: number,
       webhook: number,
       params: QueryParams & {} = {}
-    ): Promise<{ data: { id: number; url: string; suppressed_at: string } }> =>
+    ): Promise<{ data: types.Webhook }> =>
       this._client.request(
         "GET",
         `/${account}/webhooks/${webhook}`,

--- a/lib/webhooks.ts
+++ b/lib/webhooks.ts
@@ -1,5 +1,5 @@
-import type * as types from "./types";
 import type { DNSimple, QueryParams } from "./main";
+import type * as types from "./types";
 
 export class Webhooks {
   constructor(private readonly _client: DNSimple) {}
@@ -18,7 +18,7 @@ export class Webhooks {
   listWebhooks = (() => {
     const method = (
       account: number,
-      params: QueryParams & { sort?: string } = {}
+      params: QueryParams & { sort?: "id:asc" | "id:desc" } = {}
     ): Promise<{ data: Array<types.Webhook> }> =>
       this._client.request("GET", `/${account}/webhooks`, null, params);
     return method;

--- a/lib/zones.ts
+++ b/lib/zones.ts
@@ -1,6 +1,6 @@
-import type * as types from "./types";
 import type { DNSimple, QueryParams } from "./main";
 import { paginate } from "./paginate";
+import type * as types from "./types";
 
 export class Zones {
   constructor(private readonly _client: DNSimple) {}
@@ -22,16 +22,25 @@ export class Zones {
   listZones = (() => {
     const method = (
       account: number,
-      params: QueryParams & { name_like?: string; sort?: string } = {}
+      params: QueryParams & {
+        name_like?: string;
+        sort?: "id:asc" | "id:desc" | "name:asc" | "name:desc";
+      } = {}
     ): Promise<{ data: Array<types.Zone>; pagination: types.Pagination }> =>
       this._client.request("GET", `/${account}/zones`, null, params);
     method.iterateAll = (
       account: number,
-      params: QueryParams & { name_like?: string; sort?: string } = {}
+      params: QueryParams & {
+        name_like?: string;
+        sort?: "id:asc" | "id:desc" | "name:asc" | "name:desc";
+      } = {}
     ) => paginate((page) => method(account, { ...params, page } as any));
     method.collectAll = async (
       account: number,
-      params: QueryParams & { name_like?: string; sort?: string } = {}
+      params: QueryParams & {
+        name_like?: string;
+        sort?: "id:asc" | "id:desc" | "name:asc" | "name:desc";
+      } = {}
     ) => {
       const items = [];
       for await (const item of method.iterateAll(account, params)) {
@@ -167,7 +176,15 @@ export class Zones {
         name_like?: string;
         name?: string;
         type?: string;
-        sort?: string;
+        sort?:
+          | "id:asc"
+          | "id:desc"
+          | "name:asc"
+          | "name:desc"
+          | "content:asc"
+          | "content:desc"
+          | "type:asc"
+          | "type:desc";
       } = {}
     ): Promise<{
       data: Array<types.ZoneRecord>;
@@ -186,7 +203,15 @@ export class Zones {
         name_like?: string;
         name?: string;
         type?: string;
-        sort?: string;
+        sort?:
+          | "id:asc"
+          | "id:desc"
+          | "name:asc"
+          | "name:desc"
+          | "content:asc"
+          | "content:desc"
+          | "type:asc"
+          | "type:desc";
       } = {}
     ) => paginate((page) => method(account, zone, { ...params, page } as any));
     method.collectAll = async (
@@ -196,7 +221,15 @@ export class Zones {
         name_like?: string;
         name?: string;
         type?: string;
-        sort?: string;
+        sort?:
+          | "id:asc"
+          | "id:desc"
+          | "name:asc"
+          | "name:desc"
+          | "content:asc"
+          | "content:desc"
+          | "type:asc"
+          | "type:desc";
       } = {}
     ) => {
       const items = [];
@@ -225,11 +258,11 @@ export class Zones {
       zone: string,
       data: Partial<{
         name: string;
-        type: string;
+        type: types.ZoneRecordType;
         content: string;
         ttl: number;
         priority: number;
-        regions: Array<string>;
+        regions: Array<types.ZoneRecordRegion>;
       }>,
       params: QueryParams & {} = {}
     ): Promise<{ data: types.ZoneRecord }> =>
@@ -292,7 +325,7 @@ export class Zones {
         content: string;
         ttl: number;
         priority: number;
-        regions: Array<string>;
+        regions: Array<types.ZoneRecordRegion>;
       }>,
       params: QueryParams & {} = {}
     ): Promise<{ data: types.ZoneRecord }> =>

--- a/lib/zones.ts
+++ b/lib/zones.ts
@@ -1,3 +1,4 @@
+import type * as types from "./types";
 import type { DNSimple, QueryParams } from "./main";
 import { paginate } from "./paginate";
 
@@ -22,24 +23,8 @@ export class Zones {
     const method = (
       account: number,
       params: QueryParams & { name_like?: string; sort?: string } = {}
-    ): Promise<{
-      data: Array<{
-        id: number;
-        account_id: number;
-        name: string;
-        reverse: boolean;
-        secondary: boolean;
-        last_transferred_at: string;
-        created_at: string;
-        updated_at: string;
-      }>;
-      pagination: {
-        current_page: number;
-        per_page: number;
-        total_entries: number;
-        total_pages: number;
-      };
-    }> => this._client.request("GET", `/${account}/zones`, null, params);
+    ): Promise<{ data: Array<types.Zone>; pagination: types.Pagination }> =>
+      this._client.request("GET", `/${account}/zones`, null, params);
     method.iterateAll = (
       account: number,
       params: QueryParams & { name_like?: string; sort?: string } = {}
@@ -73,18 +58,7 @@ export class Zones {
       account: number,
       zone: string,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        account_id: number;
-        name: string;
-        reverse: boolean;
-        secondary: boolean;
-        last_transferred_at: string;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+    ): Promise<{ data: types.Zone }> =>
       this._client.request("GET", `/${account}/zones/${zone}`, null, params);
     return method;
   })();
@@ -105,7 +79,7 @@ export class Zones {
       account: number,
       zone: string,
       params: QueryParams & {} = {}
-    ): Promise<{ data: { zone: string } }> =>
+    ): Promise<{ data: types.ZoneFile }> =>
       this._client.request(
         "GET",
         `/${account}/zones/${zone}/file`,
@@ -131,7 +105,7 @@ export class Zones {
       account: number,
       zone: string,
       params: QueryParams & {} = {}
-    ): Promise<{ data: { distributed: boolean } }> =>
+    ): Promise<{ data: types.ZoneDistribution }> =>
       this._client.request(
         "GET",
         `/${account}/zones/${zone}/distribution`,
@@ -156,24 +130,9 @@ export class Zones {
     const method = (
       account: number,
       zone: string,
-      data: { ns_names?: Array<string>; ns_set_ids?: Array<number> },
+      data: Partial<{ ns_names: Array<string>; ns_set_ids: Array<number> }>,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: Array<{
-        id: number;
-        zone_id: string;
-        parent_id: number | null;
-        name: string;
-        content: string;
-        ttl: number;
-        priority?: number | null;
-        type: string;
-        regions: Array<string>;
-        system_record: boolean;
-        created_at: string;
-        updated_at: string;
-      }>;
-    }> =>
+    ): Promise<{ data: Array<types.ZoneRecord> }> =>
       this._client.request(
         "PUT",
         `/${account}/zones/${zone}/ns_records`,
@@ -211,26 +170,8 @@ export class Zones {
         sort?: string;
       } = {}
     ): Promise<{
-      data: Array<{
-        id: number;
-        zone_id: string;
-        parent_id: number | null;
-        name: string;
-        content: string;
-        ttl: number;
-        priority?: number | null;
-        type: string;
-        regions: Array<string>;
-        system_record: boolean;
-        created_at: string;
-        updated_at: string;
-      }>;
-      pagination: {
-        current_page: number;
-        per_page: number;
-        total_entries: number;
-        total_pages: number;
-      };
+      data: Array<types.ZoneRecord>;
+      pagination: types.Pagination;
     }> =>
       this._client.request(
         "GET",
@@ -282,31 +223,16 @@ export class Zones {
     const method = (
       account: number,
       zone: string,
-      data: {
-        name?: string;
-        type?: string;
-        content?: string;
-        ttl?: number;
-        priority?: number;
-        regions?: Array<string>;
-      },
-      params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        zone_id: string;
-        parent_id: number | null;
+      data: Partial<{
         name: string;
+        type: string;
         content: string;
         ttl: number;
-        priority?: number | null;
-        type: string;
+        priority: number;
         regions: Array<string>;
-        system_record: boolean;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+      }>,
+      params: QueryParams & {} = {}
+    ): Promise<{ data: types.ZoneRecord }> =>
       this._client.request(
         "POST",
         `/${account}/zones/${zone}/records`,
@@ -334,22 +260,7 @@ export class Zones {
       zone: string,
       zonerecord: number,
       params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        zone_id: string;
-        parent_id: number | null;
-        name: string;
-        content: string;
-        ttl: number;
-        priority?: number | null;
-        type: string;
-        regions: Array<string>;
-        system_record: boolean;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+    ): Promise<{ data: types.ZoneRecord }> =>
       this._client.request(
         "GET",
         `/${account}/zones/${zone}/records/${zonerecord}`,
@@ -376,30 +287,15 @@ export class Zones {
       account: number,
       zone: string,
       zonerecord: number,
-      data: {
-        name?: string;
-        content?: string;
-        ttl?: number;
-        priority?: number;
-        regions?: Array<string>;
-      },
-      params: QueryParams & {} = {}
-    ): Promise<{
-      data: {
-        id: number;
-        zone_id: string;
-        parent_id: number | null;
+      data: Partial<{
         name: string;
         content: string;
         ttl: number;
-        priority?: number | null;
-        type: string;
+        priority: number;
         regions: Array<string>;
-        system_record: boolean;
-        created_at: string;
-        updated_at: string;
-      };
-    }> =>
+      }>,
+      params: QueryParams & {} = {}
+    ): Promise<{ data: types.ZoneRecord }> =>
       this._client.request(
         "PATCH",
         `/${account}/zones/${zone}/records/${zonerecord}`,
@@ -455,7 +351,7 @@ export class Zones {
       zone: string,
       zonerecord: number,
       params: QueryParams & {} = {}
-    ): Promise<{ data: { distributed: boolean } }> =>
+    ): Promise<{ data: types.ZoneDistribution }> =>
       this._client.request(
         "GET",
         `/${account}/zones/${zone}/records/${zonerecord}/distribution`,

--- a/test/certificates.spec.ts
+++ b/test/certificates.spec.ts
@@ -37,11 +37,11 @@ describe("certificates", () => {
 
     it("supports sorting", (done) => {
       nock("https://api.dnsimple.com")
-        .get("/v2/1010/domains/example.com/certificates?sort=expires_on%3Aasc")
+        .get("/v2/1010/domains/example.com/certificates?sort=expiration%3Aasc")
         .reply(fixture.statusCode, fixture.body);
 
       dnsimple.certificates.listCertificates(accountId, domainId, {
-        sort: "expires_on:asc",
+        sort: "expiration:asc",
       });
 
       nock.isDone();

--- a/test/contacts.spec.ts
+++ b/test/contacts.spec.ts
@@ -34,10 +34,10 @@ describe("contacts", () => {
 
     it("supports sorting", (done) => {
       nock("https://api.dnsimple.com")
-        .get("/v2/1010/contacts?sort=first_name%3Aasc")
+        .get("/v2/1010/contacts?sort=label%3Aasc")
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.contacts.listContacts(accountId, { sort: "first_name:asc" });
+      dnsimple.contacts.listContacts(accountId, { sort: "label:asc" });
 
       nock.isDone();
       done();

--- a/test/domain_delegation_signer_records.spec.ts
+++ b/test/domain_delegation_signer_records.spec.ts
@@ -39,11 +39,11 @@ describe("domains", () => {
 
     it("supports sorting", (done) => {
       nock("https://api.dnsimple.com")
-        .get("/v2/1010/domains/example.com/ds_records?sort=from%3Aasc")
+        .get("/v2/1010/domains/example.com/ds_records?sort=created_at%3Aasc")
         .reply(fixture.statusCode, fixture.body);
 
       dnsimple.domains.listDelegationSignerRecords(accountId, domainId, {
-        sort: "from:asc",
+        sort: "created_at:asc",
       });
 
       nock.isDone();

--- a/test/services.spec.ts
+++ b/test/services.spec.ts
@@ -32,10 +32,10 @@ describe("services", () => {
 
     it("supports sorting", (done) => {
       nock("https://api.dnsimple.com")
-        .get("/v2/services?sort=name%3Aasc")
+        .get("/v2/services?sort=sid%3Aasc")
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.services.listServices({ sort: "name:asc" });
+      dnsimple.services.listServices({ sort: "sid:asc" });
 
       nock.isDone();
       done();

--- a/test/zone_records.spec.ts
+++ b/test/zone_records.spec.ts
@@ -197,7 +197,7 @@ describe("zone records", () => {
     const zoneId = "example.com";
     const attributes = {
       name: "",
-      type: "A",
+      type: "A" as const,
       ttl: 3600,
       content: "1.2.3.4",
     };

--- a/test/zones.spec.ts
+++ b/test/zones.spec.ts
@@ -34,10 +34,10 @@ describe("zones", () => {
 
     it("supports sorting", (done) => {
       nock("https://api.dnsimple.com")
-        .get("/v2/1010/zones?sort=expires_on%3Aasc")
+        .get("/v2/1010/zones?sort=name%3Aasc")
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.zones.listZones(accountId, { sort: "expires_on:asc" });
+      dnsimple.zones.listZones(accountId, { sort: "name:asc" });
 
       nock.isDone();
       done();


### PR DESCRIPTION
This moves common types (e.g. response data) to `types.ts` with names to allow them to be easily used and referenced from user code. Values of enums are also provided for stricter better type checking and autocomplete.

We export them directly at the package level instead of a submodule as it's not possible to import in a nested fashion in TS or JS. We do not have many exports at the package level anyway, so this is safe. We don't require directly importing from the file as we don't want to make the file path part of our public API. Therefore, types can be imported from user code as such:

```
import { Account, Certificate } from "dnsimple";
```