### PR TITLE
Add support to activate and deactivate DNS services for a zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## main
 
+## 7.1.1 (Unreleased)
+
+FEATURES:
+
+- NEW: Added `Zones.activateDns` to activate DNS services (resolution) for a zone. (dnsimple/dnsimple-node#180)
+- NEW: Added `Zones.deactivateDns` to deactivate DNS services (resolution) for a zone. (dnsimple/dnsimple-node#180)
+
 ## 7.1.0
 
 FEATURES

--- a/lib/zones.ts
+++ b/lib/zones.ts
@@ -21,7 +21,12 @@ export class Zones {
       zone: string,
       params: QueryParams & {} = {}
     ): Promise<{ data: types.Zone }> =>
-      this._client.request("PUT", `/${account}/zones/${zone}/activation`, null, params);
+      this._client.request(
+        "PUT",
+        `/${account}/zones/${zone}/activation`,
+        null,
+        params
+      );
     return method;
   })();
 
@@ -41,7 +46,12 @@ export class Zones {
       zone: string,
       params: QueryParams & {} = {}
     ): Promise<{ data: types.Zone }> =>
-      this._client.request("DELETE", `/${account}/zones/${zone}/activation`, null, params);
+      this._client.request(
+        "DELETE",
+        `/${account}/zones/${zone}/activation`,
+        null,
+        params
+      );
     return method;
   })();
 

--- a/lib/zones.ts
+++ b/lib/zones.ts
@@ -6,6 +6,46 @@ export class Zones {
   constructor(private readonly _client: DNSimple) {}
 
   /**
+   * Activate DNS resolution for the zone in the account.
+   *
+   * PUT /{account}/zones/{zone}/activation
+   *
+   * @see https://developer.dnsimple.com/v2/zones/#activateZoneService
+   *
+   * @param account The account id
+   * @param zone The zone name
+   */
+  activateDns = (() => {
+    const method = (
+      account: number,
+      zone: string,
+      params: QueryParams & {} = {}
+    ): Promise<{ data: types.Zone }> =>
+      this._client.request("PUT", `/${account}/zones/${zone}/activation`, null, params);
+    return method;
+  })();
+
+  /**
+   * Deativate DNS resolution for the zone in the account.
+   *
+   * DELETE /{account}/zones/{zone}/activation
+   *
+   * @see https://developer.dnsimple.com/v2/zones/#deactivateZoneService
+   *
+   * @param account The account id
+   * @param zone The zone name
+   */
+  deactivateDns = (() => {
+    const method = (
+      account: number,
+      zone: string,
+      params: QueryParams & {} = {}
+    ): Promise<{ data: types.Zone }> =>
+      this._client.request("DELETE", `/${account}/zones/${zone}/activation`, null, params);
+    return method;
+  })();
+
+  /**
    * Lists the zones in the account.
    *
    * This API is paginated. Call `listZones.iterateAll(account, params)` to get an asynchronous iterator over individual items across all pages. You can also use `await listZones.collectAll(account, params)` to quickly retrieve all items across all pages into an array. We suggest using `iterateAll` when possible, as `collectAll` will make all requests at once, which may increase latency and trigger rate limits.

--- a/test/fixtures.http/activateZoneService/success.http
+++ b/test/fixtures.http/activateZoneService/success.http
@@ -1,0 +1,16 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Tue, 08 Aug 2023 04:19:23 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2399
+X-RateLimit-Reset: 1691471963
+X-WORK-WITH-US: Love automation? So do we! https://dnsimple.com/jobs
+ETag: W/"fe6afd982459be33146933235343d51d"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 8e8ac535-9f46-4304-8440-8c68c30427c3
+X-Runtime: 0.176579
+Strict-Transport-Security: max-age=63072000
+
+{"data":{"id":1,"account_id":1010,"name":"example.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}

--- a/test/fixtures.http/deactivateZoneService/success.http
+++ b/test/fixtures.http/deactivateZoneService/success.http
@@ -1,0 +1,16 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Tue, 08 Aug 2023 04:19:52 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2398
+X-RateLimit-Reset: 1691471962
+X-WORK-WITH-US: Love automation? So do we! https://dnsimple.com/jobs
+ETag: W/"5f30a37d01b99bb9e620ef1bbce9a014"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: d2f7bba4-4c81-4818-81d2-c9bbe95f104e
+X-Runtime: 0.133278
+Strict-Transport-Security: max-age=63072000
+
+{"data":{"id":1,"account_id":1010,"name":"example.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":false,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}

--- a/test/zones.spec.ts
+++ b/test/zones.spec.ts
@@ -6,6 +6,60 @@ import { createTestClient, loadFixture } from "./util";
 const dnsimple = createTestClient();
 
 describe("zones", () => {
+  describe("#activateDns", () => {
+    const accountId = 1010;
+    const fixture = loadFixture("activateZoneService/success.http");
+
+    it("produces a zone", (done) => {
+      nock("https://api.dnsimple.com")
+        .put("/v2/1010/zones/example.com")
+        .reply(fixture.statusCode, fixture.body);
+
+      dnsimple.zones.activateDns(accountId, "example.com").then(
+        (response) => {
+          const zone = response.data;
+          expect(zone.id).to.eq(1);
+          expect(zone.account_id).to.eq(1010);
+          expect(zone.name).to.eq("example.com");
+          expect(zone.reverse).to.eq(false);
+          expect(zone.created_at).to.eq("2015-04-23T07:40:03Z");
+          expect(zone.updated_at).to.eq("2015-04-23T07:40:03Z");
+          done();
+        },
+        (error) => {
+          done(error);
+        }
+      );
+    });
+  });
+
+  describe("#deactivateDns", () => {
+    const accountId = 1010;
+    const fixture = loadFixture("deactivateZoneService/success.http");
+
+    it("produces a zone", (done) => {
+      nock("https://api.dnsimple.com")
+        .delete("/v2/1010/zones/example.com")
+        .reply(fixture.statusCode, fixture.body);
+
+      dnsimple.zones.activateDns(accountId, "example.com").then(
+        (response) => {
+          const zone = response.data;
+          expect(zone.id).to.eq(1);
+          expect(zone.account_id).to.eq(1010);
+          expect(zone.name).to.eq("example.com");
+          expect(zone.reverse).to.eq(false);
+          expect(zone.created_at).to.eq("2015-04-23T07:40:03Z");
+          expect(zone.updated_at).to.eq("2015-04-23T07:40:03Z");
+          done();
+        },
+        (error) => {
+          done(error);
+        }
+      );
+    });
+  });
+
   describe("#listZones", () => {
     const accountId = 1010;
     const fixture = loadFixture("listZones/success.http");

--- a/test/zones.spec.ts
+++ b/test/zones.spec.ts
@@ -12,7 +12,7 @@ describe("zones", () => {
 
     it("produces a zone", (done) => {
       nock("https://api.dnsimple.com")
-        .put("/v2/1010/zones/example.com")
+        .put("/v2/1010/zones/example.com/activation")
         .reply(fixture.statusCode, fixture.body);
 
       dnsimple.zones.activateDns(accountId, "example.com").then(
@@ -39,7 +39,7 @@ describe("zones", () => {
 
     it("produces a zone", (done) => {
       nock("https://api.dnsimple.com")
-        .delete("/v2/1010/zones/example.com")
+        .delete("/v2/1010/zones/example.com/activation")
         .reply(fixture.statusCode, fixture.body);
 
       dnsimple.zones.deactivateDns(accountId, "example.com").then(

--- a/test/zones.spec.ts
+++ b/test/zones.spec.ts
@@ -42,7 +42,7 @@ describe("zones", () => {
         .delete("/v2/1010/zones/example.com")
         .reply(fixture.statusCode, fixture.body);
 
-      dnsimple.zones.activateDns(accountId, "example.com").then(
+      dnsimple.zones.deactivateDns(accountId, "example.com").then(
         (response) => {
           const zone = response.data;
           expect(zone.id).to.eq(1);


### PR DESCRIPTION
This PR implements https://github.com/dnsimple/dnsimple-developer/pull/502 which allows for the management of DNS resolution for a particular zone.

Belongs to https://github.com/dnsimple/dnsimple-external-integrations/issues/3
Belongs to https://github.com/dnsimple/dnsimple-external-integrations/issues/2