### PR TITLE
Add support for registrant APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## main
 
-## 7.1.2 (Unreleased)
+## 7.2.0 (Unreleased)
 
 FEATURES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 FEATURES:
 
-- NEW: Added `Registrar.createRegistrantChange` to start a registrant change. (dnsimple/dnsimple-node#181)
+- NEW: Added `listRegistrantChanges`, `createRegistrantChange`, `checkRegistrantChange`, `getRegistrantChange`, and `deleteRegistrantChange` APIs to manage registrant changes. (dnsimple/dnsimple-node#181)
 
 ## 7.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## main
 
+## 7.1.2 (Unreleased)
+
+FEATURES:
+
+- NEW: Added `Registrar.createRegistrantChange` to start a registrant change. (dnsimple/dnsimple-node#181)
+
 ## 7.1.1
 
 FEATURES:

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -246,7 +246,7 @@ export class DNSimple {
       return {};
     }
     if (status >= 200 && status < 300) {
-      return JSON.parse(data);
+      return !data ? {} : JSON.parse(data);
     }
     if (status >= 500) {
       throw new ServerError(status, JSON.parse(data));

--- a/lib/registrar.ts
+++ b/lib/registrar.ts
@@ -608,9 +608,9 @@ export class Registrar {
     const method = (
       account: number,
       change: {
-        domain_id: string,
-        contact_id: string,
-        extended_attributes: Record<string, string>,
+        domain_id: string;
+        contact_id: string;
+        extended_attributes: Record<string, string>;
       },
       params: QueryParams & {} = {}
     ): Promise<{ data: types.RegistrantChange }> =>
@@ -618,7 +618,7 @@ export class Registrar {
         "POST",
         `/${account}/registrar/registrant_changes`,
         change,
-        params,
+        params
       );
     return method;
   })();

--- a/lib/registrar.ts
+++ b/lib/registrar.ts
@@ -592,4 +592,34 @@ export class Registrar {
       );
     return method;
   })();
+
+  /**
+   * Starts a registrant change.
+   *
+   * POST /{account}/registrar/registrant_changes
+   *
+   * @see https://developer.dnsimple.com/v2/registrar/#createRegistrantChange
+   *
+   * @param account The account id
+   * @param change The change details
+   * @param params Query parameters
+   */
+  createRegistrantChange = (() => {
+    const method = (
+      account: number,
+      change: {
+        domain_id: string,
+        contact_id: string,
+        extended_attributes: Record<string, string>,
+      },
+      params: QueryParams & {} = {}
+    ): Promise<{ data: types.RegistrantChange }> =>
+      this._client.request(
+        "POST",
+        `/${account}/registrar/registrant_changes`,
+        change,
+        params,
+      );
+    return method;
+  })();
 }

--- a/lib/registrar.ts
+++ b/lib/registrar.ts
@@ -1,4 +1,5 @@
 import type { DNSimple, QueryParams } from "./main";
+import { paginate } from "./paginate";
 import type * as types from "./types";
 
 export class Registrar {
@@ -593,31 +594,174 @@ export class Registrar {
     return method;
   })();
 
+
+
   /**
-   * Starts a registrant change.
+   * List registrant changes in the account.
+   *
+   * This API is paginated. Call `listRegistrantChanges.iterateAll(account, params)` to get an asynchronous iterator over individual items across all pages. You can also use `await listRegistrantChanges.collectAll(account, params)` to quickly retrieve all items across all pages into an array. We suggest using `iterateAll` when possible, as `collectAll` will make all requests at once, which may increase latency and trigger rate limits.
+   *
+   * GET /{account}/registrar/registrant_changes
+   *
+   * @see https://developer.dnsimple.com/v2/registrar/#listRegistrantChanges
+   *
+   * @param account The account id
+   * @param params Query parameters
+   * @param params.sort Sort results. Default sorting is by id.
+   * @param params.state Only include results with a state field exactly matching the given string
+   * @param params.domain_id Only include results with a domain_id field exactly matching the given string
+   * @param params.contact_id Only include results with a contact_id field exactly matching the given string
+   */
+  listRegistrantChanges = (() => {
+    const method = (
+      account: number,
+      params: QueryParams & {
+        sort?: "id:asc" | "id:desc";
+        state?: "new" | "pending" | "completed" | "cancelling" | "cancelled";
+        domain_id?: string;
+        contact_id?: string;
+      } = {}
+    ): Promise<{
+      data: Array<types.RegistrantChange>;
+      pagination: types.Pagination;
+    }> =>
+      this._client.request(
+        "GET",
+        `/${account}/registrar/registrant_changes`,
+        null,
+        params
+      );
+    method.iterateAll = (
+      account: number,
+      params: QueryParams & {
+        sort?: "id:asc" | "id:desc";
+        state?: "new" | "pending" | "completed" | "cancelling" | "cancelled";
+        domain_id?: string;
+        contact_id?: string;
+      } = {}
+    ) => paginate((page) => method(account, { ...params, page } as any));
+    method.collectAll = async (
+      account: number,
+      params: QueryParams & {
+        sort?: "id:asc" | "id:desc";
+        state?: "new" | "pending" | "completed" | "cancelling" | "cancelled";
+        domain_id?: string;
+        contact_id?: string;
+      } = {}
+    ) => {
+      const items = [];
+      for await (const item of method.iterateAll(account, params)) {
+        items.push(item);
+      }
+      return items;
+    };
+    return method;
+  })();
+
+  /**
+   * Start registrant change.
    *
    * POST /{account}/registrar/registrant_changes
    *
    * @see https://developer.dnsimple.com/v2/registrar/#createRegistrantChange
    *
    * @param account The account id
-   * @param change The change details
    * @param params Query parameters
    */
   createRegistrantChange = (() => {
     const method = (
       account: number,
-      change: {
-        domain_id: string;
-        contact_id: string;
+      data: Partial<{
+        domain_id: string | number;
+        contact_id: string | number;
         extended_attributes: Record<string, string>;
-      },
+      }>,
       params: QueryParams & {} = {}
     ): Promise<{ data: types.RegistrantChange }> =>
       this._client.request(
         "POST",
         `/${account}/registrar/registrant_changes`,
-        change,
+        data,
+        params
+      );
+    return method;
+  })();
+
+  /**
+   * Retrieves the requirements of a registrant change.
+   *
+   * POST /{account}/registrar/registrant_changes/check
+   *
+   * @see https://developer.dnsimple.com/v2/registrar/#checkRegistrantChange
+   *
+   * @param account The account id
+   * @param params Query parameters
+   */
+  checkRegistrantChange = (() => {
+    const method = (
+      account: number,
+      data: Partial<{
+        domain_id: string | number;
+        contact_id: string | number;
+      }>,
+      params: QueryParams & {} = {}
+    ): Promise<{ data: types.RegistrantChangeCheck }> =>
+      this._client.request(
+        "POST",
+        `/${account}/registrar/registrant_changes/check`,
+        data,
+        params
+      );
+    return method;
+  })();
+
+  /**
+   * Retrieves the details of an existing registrant change.
+   *
+   * GET /{account}/registrar/registrant_changes/{registrantchange}
+   *
+   * @see https://developer.dnsimple.com/v2/registrar/#getRegistrantChange
+   *
+   * @param account The account id
+   * @param registrantchange The registrant change id
+   * @param params Query parameters
+   */
+  getRegistrantChange = (() => {
+    const method = (
+      account: number,
+      registrantchange: number,
+      params: QueryParams & {} = {}
+    ): Promise<{ data: types.RegistrantChange }> =>
+      this._client.request(
+        "GET",
+        `/${account}/registrar/registrant_changes/${registrantchange}`,
+        null,
+        params
+      );
+    return method;
+  })();
+
+  /**
+   * Cancel an ongoing registrant change from the account.
+   *
+   * DELETE /{account}/registrar/registrant_changes/{registrantchange}
+   *
+   * @see https://developer.dnsimple.com/v2/registrar/#deleteRegistrantChange
+   *
+   * @param account The account id
+   * @param registrantchange The registrant change id
+   * @param params Query parameters
+   */
+  deleteRegistrantChange = (() => {
+    const method = (
+      account: number,
+      registrantchange: number,
+      params: QueryParams & {} = {}
+    ): Promise<{}> =>
+      this._client.request(
+        "DELETE",
+        `/${account}/registrar/registrant_changes/${registrantchange}`,
+        null,
         params
       );
     return method;

--- a/lib/registrar.ts
+++ b/lib/registrar.ts
@@ -594,8 +594,6 @@ export class Registrar {
     return method;
   })();
 
-
-
   /**
    * List registrant changes in the account.
    *

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -259,20 +259,6 @@ export type WhoisPrivacyRenewal = {
   updated_at: string;
 };
 
-export type RegistrantChange = {
-  id: number;
-  type: number;
-  account_id: number;
-  contact_id: number;
-  domain_id: number;
-  state: string;
-  extended_attributes: Record<string, string>;
-  registry_owner_change: boolean;
-  irt_lock_lifted_by: string;
-  created_at: string;
-  updated_at: string;
-};
-
 export type PrimaryServer = {
   id: number;
   account_id: number;
@@ -442,3 +428,23 @@ export type VanityNameServer = {
 };
 
 export type Webhook = { id: number; url: string; suppressed_at: string };
+
+export type RegistrantChange = {
+  id: number;
+  account_id: number;
+  contact_id: number;
+  domain_id: number;
+  state: "new" | "pending" | "cancelling" | "cancelled" | "completed";
+  extended_attributes: Record<string, string>;
+  registry_owner_change: boolean;
+  irt_lock_lifted_by: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type RegistrantChangeCheck = {
+  contact_id: number;
+  domain_id: number;
+  extended_attributes: Array<ExtendedAttribute>;
+  registry_owner_change: boolean;
+};

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -260,17 +260,17 @@ export type WhoisPrivacyRenewal = {
 };
 
 export type RegistrantChange = {
-  id: number,
-  type: number,
-  account_id: number,
-  contact_id: number,
-  domain_id: number,
-  state: string,
-  extended_attributes: Record<string, string>,
-  registry_owner_change: boolean,
-  irt_lock_lifted_by: string,
-  created_at: string,
-  updated_at: string,
+  id: number;
+  type: number;
+  account_id: number;
+  contact_id: number;
+  domain_id: number;
+  state: string;
+  extended_attributes: Record<string, string>;
+  registry_owner_change: boolean;
+  irt_lock_lifted_by: string;
+  created_at: string;
+  updated_at: string;
 };
 
 export type PrimaryServer = {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -259,6 +259,20 @@ export type WhoisPrivacyRenewal = {
   updated_at: string;
 };
 
+export type RegistrantChange = {
+  id: number,
+  type: number,
+  account_id: number,
+  contact_id: number,
+  domain_id: number,
+  state: string,
+  extended_attributes: Record<string, string>,
+  registry_owner_change: boolean,
+  irt_lock_lifted_by: string,
+  created_at: string,
+  updated_at: string,
+};
+
 export type PrimaryServer = {
   id: number;
   account_id: number;

--- a/test/fixtures.http/checkRegistrantChange/success.http
+++ b/test/fixtures.http/checkRegistrantChange/success.http
@@ -1,0 +1,15 @@
+HTTP/2 200 
+server: nginx
+date: Tue, 22 Aug 2023 11:09:40 GMT
+content-type: application/json; charset=utf-8
+x-ratelimit-limit: 2400
+x-ratelimit-remaining: 2395
+x-ratelimit-reset: 1692705338
+x-work-with-us: Love automation? So do we! https://dnsimple.com/jobs
+etag: W/"cef1e7d85d0b9bfd25e81b812891d34f"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: 5b0d8bfb-7b6a-40b5-a079-b640fd817e34
+x-runtime: 3.066249
+strict-transport-security: max-age=63072000
+
+{"data":{"domain_id":101,"contact_id":101,"extended_attributes":[],"registry_owner_change":true}}

--- a/test/fixtures.http/createRegistrantChange/success.http
+++ b/test/fixtures.http/createRegistrantChange/success.http
@@ -1,0 +1,14 @@
+HTTP/2 202 
+server: nginx
+date: Tue, 22 Aug 2023 11:11:00 GMT
+content-type: application/json; charset=utf-8
+x-ratelimit-limit: 2400
+x-ratelimit-remaining: 2394
+x-ratelimit-reset: 1692705339
+x-work-with-us: Love automation? So do we! https://dnsimple.com/jobs
+cache-control: no-cache
+x-request-id: 26bf7ff9-2075-42b0-9431-1778c825b6b0
+x-runtime: 3.408950
+strict-transport-security: max-age=63072000
+
+{"data":{"id":101,"account_id":101,"domain_id":101,"contact_id":101,"state":"new","extended_attributes":{},"registry_owner_change":true,"irt_lock_lifted_by":null,"created_at":"2017-02-03T17:43:22Z","updated_at":"2017-02-03T17:43:22Z"}}

--- a/test/fixtures.http/deleteRegistrantChange/success.http
+++ b/test/fixtures.http/deleteRegistrantChange/success.http
@@ -1,0 +1,13 @@
+HTTP/2 201 
+server: nginx
+date: Tue, 22 Aug 2023 11:14:44 GMT
+content-type: application/json; charset=utf-8
+x-ratelimit-limit: 2400
+x-ratelimit-remaining: 2391
+x-ratelimit-reset: 1692705338
+x-work-with-us: Love automation? So do we! https://dnsimple.com/jobs
+cache-control: no-cache
+x-request-id: b123e1f0-aa70-4abb-95cf-34f377c83ef4
+x-runtime: 0.114839
+strict-transport-security: max-age=63072000
+

--- a/test/fixtures.http/deleteRegistrantChange/success.http
+++ b/test/fixtures.http/deleteRegistrantChange/success.http
@@ -1,7 +1,6 @@
-HTTP/2 201 
+HTTP/2 201
 server: nginx
 date: Tue, 22 Aug 2023 11:14:44 GMT
-content-type: application/json; charset=utf-8
 x-ratelimit-limit: 2400
 x-ratelimit-remaining: 2391
 x-ratelimit-reset: 1692705338
@@ -10,4 +9,3 @@ cache-control: no-cache
 x-request-id: b123e1f0-aa70-4abb-95cf-34f377c83ef4
 x-runtime: 0.114839
 strict-transport-security: max-age=63072000
-

--- a/test/fixtures.http/deleteRegistrantChange/success.http
+++ b/test/fixtures.http/deleteRegistrantChange/success.http
@@ -1,6 +1,7 @@
-HTTP/2 201
+HTTP/2 201 
 server: nginx
 date: Tue, 22 Aug 2023 11:14:44 GMT
+content-type: application/json; charset=utf-8
 x-ratelimit-limit: 2400
 x-ratelimit-remaining: 2391
 x-ratelimit-reset: 1692705338
@@ -9,3 +10,4 @@ cache-control: no-cache
 x-request-id: b123e1f0-aa70-4abb-95cf-34f377c83ef4
 x-runtime: 0.114839
 strict-transport-security: max-age=63072000
+

--- a/test/fixtures.http/getRegistrantChange/success.http
+++ b/test/fixtures.http/getRegistrantChange/success.http
@@ -1,0 +1,15 @@
+HTTP/2 200 
+server: nginx
+date: Tue, 22 Aug 2023 11:13:58 GMT
+content-type: application/json; charset=utf-8
+x-ratelimit-limit: 2400
+x-ratelimit-remaining: 2392
+x-ratelimit-reset: 1692705338
+x-work-with-us: Love automation? So do we! https://dnsimple.com/jobs
+etag: W/"76c5d4c7579b754b94a42ac7fa37a901"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: e910cd08-3f9c-4da4-9986-50dbe9c3bc55
+x-runtime: 0.022006
+strict-transport-security: max-age=63072000
+
+{"data":{"id":101,"account_id":101,"domain_id":101,"contact_id":101,"state":"new","extended_attributes":{},"registry_owner_change":true,"irt_lock_lifted_by":null,"created_at":"2017-02-03T17:43:22Z","updated_at":"2017-02-03T17:43:22Z"}}

--- a/test/fixtures.http/listRegistrantChanges/success.http
+++ b/test/fixtures.http/listRegistrantChanges/success.http
@@ -1,0 +1,15 @@
+HTTP/2 200 
+server: nginx
+date: Tue, 22 Aug 2023 11:12:49 GMT
+content-type: application/json; charset=utf-8
+x-ratelimit-limit: 2400
+x-ratelimit-remaining: 2393
+x-ratelimit-reset: 1692705338
+x-work-with-us: Love automation? So do we! https://dnsimple.com/jobs
+etag: W/"0049703ea058b06346df4c0e169eac29"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: fd0334ce-414a-4872-8889-e548e0b1410c
+x-runtime: 0.030759
+strict-transport-security: max-age=63072000
+
+{"data":[{"id":101,"account_id":101,"domain_id":101,"contact_id":101,"state":"new","extended_attributes":{},"registry_owner_change":true,"irt_lock_lifted_by":null,"created_at":"2017-02-03T17:43:22Z","updated_at":"2017-02-03T17:43:22Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":1,"total_pages":1}}

--- a/test/registrar_registrant.spec.ts
+++ b/test/registrar_registrant.spec.ts
@@ -1,0 +1,122 @@
+import { expect } from "chai";
+import * as nock from "nock";
+import { createTestClient, loadFixture } from "./util";
+
+const dnsimple = createTestClient();
+
+describe("registrant", () => {
+  const accountId = 1010;
+
+  describe("#checkRegistrantChange", () => {
+    const fixture = loadFixture("checkRegistrantChange/success.http");
+
+    it("produces a registrant change", (done) => {
+      nock("https://api.dnsimple.com")
+        .post("/v2/1010/registrar/registrant_changes/check")
+        .reply(fixture.statusCode, fixture.body);
+
+      dnsimple.registrar
+        .checkRegistrantChange(accountId, {
+          contact_id: 101,
+          domain_id: 101,
+        })
+        .then(
+          ({ data }) => {
+            expect(data.domain_id).to.eq(101);
+            expect(data.contact_id).to.eq(101);
+            expect(data.extended_attributes).to.deep.eq([]);
+            expect(data.registry_owner_change).to.eq(true);
+            done();
+          },
+          (error) => {
+            done(error);
+          }
+        );
+    });
+  });
+
+  describe("#createRegistrantChange", () => {
+    const fixture = loadFixture("createRegistrantChange/success.http");
+
+    it("produces a registrant change", (done) => {
+      nock("https://api.dnsimple.com")
+        .post("/v2/1010/registrar/registrant_changes")
+        .reply(fixture.statusCode, fixture.body);
+
+      dnsimple.registrar
+        .createRegistrantChange(accountId, {
+          contact_id: 101,
+          domain_id: 101,
+          extended_attributes: {},
+        })
+        .then(
+          ({ data }) => {
+            expect(data.id).to.eq(101);
+            expect(data.account_id).to.eq(101);
+            expect(data.domain_id).to.eq(101);
+            expect(data.contact_id).to.eq(101);
+            expect(data.state).to.eq("new");
+            expect(data.extended_attributes).to.deep.eq({});
+            expect(data.registry_owner_change).to.eq(true);
+            expect(data.irt_lock_lifted_by).to.eq(null);
+            expect(data.created_at).to.eq("2017-02-03T17:43:22Z");
+            expect(data.created_at).to.eq("2017-02-03T17:43:22Z");
+            done();
+          },
+          (error) => {
+            done(error);
+          }
+        );
+    });
+  });
+
+  describe("#deleteRegistrantChange", () => {
+    const fixture = loadFixture("deleteRegistrantChange/success.http");
+
+    it("deletes the registrant change", (done) => {
+      nock("https://api.dnsimple.com")
+        .delete("/v2/1010/registrar/registrant_changes/101")
+        .reply(fixture.statusCode, fixture.body);
+
+      dnsimple.registrar.deleteRegistrantChange(accountId, 101).then(
+        () => {
+          done();
+        },
+        (error) => {
+          done(error);
+        }
+      );
+    });
+  });
+
+  describe("#getRegistrantChange", () => {
+    const fixture = loadFixture("getRegistrantChange/success.http");
+
+    it("returns the registrant change", (done) => {
+      nock("https://api.dnsimple.com")
+        .get("/v2/1010/registrar/registrant_changes/101")
+        .reply(fixture.statusCode, fixture.body);
+
+      dnsimple.registrar.getRegistrantChange(accountId, 101).then(
+        ({ data }) => {
+          expect(data).to.deep.eq({
+            id: 101,
+            account_id: 101,
+            domain_id: 101,
+            contact_id: 101,
+            state: "new",
+            extended_attributes: {},
+            registry_owner_change: true,
+            irt_lock_lifted_by: null,
+            created_at: "2017-02-03T17:43:22Z",
+            updated_at: "2017-02-03T17:43:22Z",
+          });
+          done();
+        },
+        (error) => {
+          done(error);
+        }
+      );
+    });
+  });
+});


### PR DESCRIPTION
This PR introduces 5 new endpoints that are part of the domain contact management API that was introduced in https://github.com/dnsimple/dnsimple-developer/pull/501.

The following endpoints have been added:
- **listRegistrantChanges**: GET `/{account}/registrar/registrant_changes`
- **createRegistrantChange**: POST `/{account}/registrar/registrant_changes`
- **checkRegistrantChange**: POST `/{account}/registrar/registrant_changes/check`
- **getRegistrantChange**: GET `/{account}/registrar/registrant_changes/{registrantchange}`
- **deleteRegistrantChange**: DELETE `/{account}/registrar/registrant_changes/{registrantchange}`

Belongs to https://github.com/dnsimple/dnsimple-business/issues/1729