### PR TITLE
Add missing attributes to the Zone API responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+ENHANCEMENTS:
+
+- NEW: Added `Secondary`, `LastTransferredAt`, `Active` to `Zone` (dnsimple/dnsimple-node)
+
 ## 7.3.0
 
 FEATURES:

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -294,6 +294,7 @@ export type Zone = {
   reverse: boolean;
   secondary: boolean;
   last_transferred_at: string;
+  active: boolean;
   created_at: string;
   updated_at: string;
 };

--- a/test/fixtures.http/getZone/success.http
+++ b/test/fixtures.http/getZone/success.http
@@ -13,4 +13,4 @@ X-Request-Id: 93182033-a215-484e-a107-5235fa48001c
 X-Runtime: 0.177942
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}
+{"data":{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}

--- a/test/fixtures.http/listZones/success.http
+++ b/test/fixtures.http/listZones/success.http
@@ -13,4 +13,4 @@ X-Request-Id: 01be9fa5-3a00-4d51-a927-f17587cb67ec
 X-Runtime: 0.037083
 Strict-Transport-Security: max-age=31536000
 
-{"data":[{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"},{"id":2,"account_id":1010,"name":"example-beta.com","reverse":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}
+{"data":[{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"},{"id":2,"account_id":1010,"name":"example-beta.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}

--- a/test/zones.spec.ts
+++ b/test/zones.spec.ts
@@ -200,6 +200,9 @@ describe("zones", () => {
           expect(zone.account_id).to.eq(1010);
           expect(zone.name).to.eq("example-alpha.com");
           expect(zone.reverse).to.eq(false);
+          expect(zone.secondary).to.eq(false);
+          expect(zone.last_transferred_at).to.eq(null);
+          expect(zone.active).to.eq(true);
           expect(zone.created_at).to.eq("2015-04-23T07:40:03Z");
           expect(zone.updated_at).to.eq("2015-04-23T07:40:03Z");
           done();


### PR DESCRIPTION
This PR adds [missing attributes](https://github.com/dnsimple/dnsimple-developer/pull/542) of the Zone response:

- `secondary`, `last_transferred_at`, `active` to `Zone` type

Belongs to https://github.com/dnsimple/dnsimple-external-integrations/issues/17