### PR TITLE
Update NodeJS runtime requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     name: Node.js ${{ matrix.node-version }}
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     name: Node.js ${{ matrix.node-version }}
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 19.x]
+        node-version: [18.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+## 8.0.0
+
+- Upgraded NodeJS runtime requirements to Node JS 18 or higher
+
 ## 7.4.0
 
 ENHANCEMENTS:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Node.js client for the [DNSimple API v2](https://developer.dnsimple.com/v2/) w
 
 ## Requirements
 
-The [dnsimple-node](https://npmjs.org/package/dnsimple-node) package requires Node.js 14.0.0 or higher.
+The [dnsimple-node](https://npmjs.org/package/dnsimple-node) package requires Node.js 18 or higher.
 
 You must also have an activated DNSimple account to access the DNSimple API.
 


### PR DESCRIPTION
In this PR:
- Remove NodeJS 14, 16, and 19 (all currently at EoL)
- Add NodeJS 20 LTS