### PR TITLE
Patch cycle - 2024 / Cycle 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     name: Node.js ${{ matrix.node-version }}
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+- NEW: Add support for node 22.x
+
 ## 8.1.0
 
 - Getting the built-in `Fecther` default instance for the `DNSimple` class constructor has been made more robust to cover more scenarios where `fetch` might be present.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## main
 
 - NEW: Add support for node 22.x
+- CHANGED: `DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.
 
 ## 8.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - NEW: Add support for node 22.x
 - CHANGED: `DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.
+- CHANGED: Updated dependencies
 
 ## 8.1.0
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2022 DNSimple Corporation
+Copyright (c) 2016-2024 DNSimple Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -114,4 +114,4 @@ The value you provide will be appended to the default `User-Agent` the client us
 
 ## License
 
-Copyright © 2016&ndash;2023 DNSimple Corporation. This is Free Software distributed under the MIT license.
+Copyright © 2016&ndash;2024 DNSimple Corporation. This is Free Software distributed under the MIT license.

--- a/lib/domains.ts
+++ b/lib/domains.ts
@@ -146,6 +146,8 @@ export class Domains {
   })();
 
   /**
+   * @deprecated since v9.0.0 - `DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.
+   *
    * Lists collaborators for the domain.
    *
    * This API is paginated. Call `listCollaborators.iterateAll(account, domain, params)` to get an asynchronous iterator over individual items across all pages. You can also use `await listCollaborators.collectAll(account, domain, params)` to quickly retrieve all items across all pages into an array. We suggest using `iterateAll` when possible, as `collectAll` will make all requests at once, which may increase latency and trigger rate limits.
@@ -194,6 +196,8 @@ export class Domains {
   })();
 
   /**
+   * @deprecated since v9.0.0 - `DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.
+   *
    * Adds a collaborator to the domain.
    *
    * At the time of the add, a collaborator may or may not have a DNSimple account. In case the collaborator doesn't have a DNSimple account, the system will invite them to register to DNSimple first and then to accept the collaboration invitation. In the other case, they are automatically added to the domain as collaborator. They can decide to reject the invitation later.
@@ -223,6 +227,8 @@ export class Domains {
   })();
 
   /**
+   * @deprecated since v9.0.0 - `DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.
+   *
    * Removes a collaborator from the domain.
    *
    * DELETE /{account}/domains/{domain}/collaborators/{collaborator}


### PR DESCRIPTION
The changes to go out in the next version (9.0.0) are:

- NEW: Add support for node 22.x
- CHANGED: `DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.
- CHANGED: Updated dependencies

Belongs to https://github.com/dnsimple/dnsimple-engineering/issues/231