### PR TITLE
Support the active attribute in EmailForward

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -91,6 +91,7 @@ export type EmailForward = {
   destination_email: string;
   from: string;
   to: string;
+  active: boolean;
   created_at: string;
   updated_at: string;
 };

--- a/test/domain_email_forwards.spec.ts
+++ b/test/domain_email_forwards.spec.ts
@@ -60,6 +60,7 @@ describe("domains", () => {
       );
 
       expect(response.data.length).toBe(1);
+      expect(response.data[0].active).toBe(true);
     });
 
     it("exposes the pagination info", async () => {
@@ -134,6 +135,7 @@ describe("domains", () => {
       expect(emailForward.to).toBe("example@example.com");
       expect(emailForward.alias_email).toBe("example@dnsimple.xyz");
       expect(emailForward.destination_email).toBe("example@example.com");
+      expect(emailForward.active).toBe(true);
       expect(emailForward.created_at).toBe("2021-01-25T13:54:40Z");
       expect(emailForward.updated_at).toBe("2021-01-25T13:54:40Z");
     });
@@ -187,6 +189,7 @@ describe("domains", () => {
       );
 
       expect(response.data.id).toBe(41872);
+      expect(response.data.active).toBe(true);
     });
   });
 


### PR DESCRIPTION
Support the `active` attribute in EmailForward

Belongs to https://github.com/dnsimple/dnsimple-engineering/issues/235