### PR TITLE
Remove from and to from EmailForwards

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -89,8 +89,6 @@ export type EmailForward = {
   domain_id: number;
   alias_email: string;
   destination_email: string;
-  from: string;
-  to: string;
   active: boolean;
   created_at: string;
   updated_at: string;

--- a/test/domain_email_forwards.spec.ts
+++ b/test/domain_email_forwards.spec.ts
@@ -131,8 +131,6 @@ describe("domains", () => {
       const emailForward = response.data;
       expect(emailForward.id).toBe(41872);
       expect(emailForward.domain_id).toBe(235146);
-      expect(emailForward.from).toBe("example@dnsimple.xyz");
-      expect(emailForward.to).toBe("example@example.com");
       expect(emailForward.alias_email).toBe("example@dnsimple.xyz");
       expect(emailForward.destination_email).toBe("example@example.com");
       expect(emailForward.active).toBe(true);


### PR DESCRIPTION
Belongs to https://github.com/dnsimple/dnsimple-app/issues/17733.

## Description
This PR removes the deprecated `from` and `to` models from the `EmailForward` model.