### PR TITLE
Dispatch release workflow from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - v*.*.*
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,23 +2,55 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - v*.*.*
+  workflow_run:
+    workflows:
+      - "CI"
+    types:
+      - completed
 
 jobs:
+  validate-tag:
+    name: Check tag
+    runs-on: ubuntu-latest
+    outputs:
+      valid_tag: ${{ steps.validation.outputs.valid_tag }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && startsWith(github.event.workflow_run.head_branch, 'v') }}
+    steps:
+      - name: Check out the repository including tags
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Validate tag
+        id: validation
+        run: |
+          # Validation is necessary in the unlikely case that a branch matching the tag naming pattern is pushed
+          # and the CI workflow in that branch is modified to run upon a push to that branch
+          REF='${{ github.event.workflow_run.head_branch }}' # This can be a branch or tag name
+          if [[ "$REF" != v*.*.* ]]; then
+            echo "valid_tag=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          # Validate that the tag exists
+          if ! git rev-parse -q --verify "refs/tags/$REF" >/dev/null; then
+            echo "There is no tag matching $REF - $REF is a branch"
+            echo "valid_tag=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          # Validate that the tag is for the same commit that was pushed
+          TAG_SHA="$(git rev-parse "$REF^{commit}")"
+          COMMIT_SHA="${{ github.event.workflow_run.head_sha }}"
+          if [ "$TAG_SHA" != "$COMMIT_SHA" ]; then
+            echo "Tag SHA $TAG_SHA does not match pushed commit SHA $COMMIT_SHA"
+            echo "valid_tag=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          echo "Tag $REF exists and is valid. Tag $TAG_SHA matches the pushed commit $COMMIT_SHA."
+          echo "valid_tag=true"  >> "$GITHUB_OUTPUT"
   publish:
     name: Publish Client
+    needs: validate-tag
     runs-on: ubuntu-latest
+    if: ${{ needs.validate-tag.outputs.valid_tag == 'true' && github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - name: Wait for tests to succeed
-        uses: lewagon/wait-on-check-action@v1.4.0
-        with:
-          ref: 'refs/heads/main'
-          running-workflow-name: 'Publish Client'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 10
-          allowed-conclusions: success
       - name: Checkout Code
         uses: actions/checkout@v5
       - name: Set up Node ${{ matrix.node-version }}


### PR DESCRIPTION
This updates our workflows to dispatch `Release` from the `CI` workflow.

A similar change was done for the dnsimple-java repository: https://github.com/dnsimple/dnsimple-java/pull/218

Currently the `Release` workflow is directly triggered upon a tag push but as discussed [here](https://github.com/dnsimple/dnsimple-java/issues/201#issuecomment-3199800867), it relies on a third-party action to validate that the CI workflow ran successfully for the tagged commit.

With the changes in this PR, we will use `workflow_run` to make the `Release` workflow run automatically when the `CI` workflow completes, with the following necessary accompanying changes:
- Trigger the `CI` workflow upon a tag push that matches a valid pattern
- We introduce a `validate-tag` job to the `Release` workflow, that validates that the `CI` workflow was triggered from a push of a valid tag, and only allows the `publish` job to run if the validation succeeds. This is necessary because the `CI` workflow can be triggered by other conditions including a push to `main` branch.

Belongs to https://github.com/dnsimple/dnsimple-engineering/issues/361