### PR TITLE
Add domain push identifier support and account name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 This project uses [Semantic Versioning 2.0.0](http://semver.org/), the format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Added
+
+- Added `new_account_identifier` option to `initiatePush` for initiating domain pushes by account identifier.
+- Added `name` to `Account`.
+
+### Deprecated
+
+- Deprecated `new_account_email` option in `initiatePush`. Use `new_account_identifier` instead.
+
 ## 12.2.0 - 2026-03-23
 
 ### Added

--- a/lib/domains.ts
+++ b/lib/domains.ts
@@ -547,7 +547,11 @@ export class Domains {
     const method = (
       account: number,
       domain: string,
-      data: Partial<{ new_account_email: string }>,
+      data: Partial<{
+        /** @deprecated Use new_domain_push_identifier instead */
+        new_account_email: string;
+        new_domain_push_identifier: string;
+      }>,
       params: QueryParams & {} = {}
     ): Promise<{ data: types.Push }> =>
       this._client.request(

--- a/lib/domains.ts
+++ b/lib/domains.ts
@@ -548,9 +548,9 @@ export class Domains {
       account: number,
       domain: string,
       data: Partial<{
-        /** @deprecated Use new_domain_push_identifier instead */
+        /** @deprecated Use new_account_identifier instead */
         new_account_email: string;
-        new_domain_push_identifier: string;
+        new_account_identifier: string;
       }>,
       params: QueryParams & {} = {}
     ): Promise<{ data: types.Push }> =>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -7,6 +7,7 @@ export type RateLimitHeaders = {
 export type Account = {
   id: number;
   email: string;
+  name: string;
   plan_identifier: string;
   created_at: string;
   updated_at: string;

--- a/test/accounts.spec.ts
+++ b/test/accounts.spec.ts
@@ -17,6 +17,7 @@ describe("accounts", () => {
         {
           id: 123,
           email: "john@example.com",
+          name: "John",
           plan_identifier: "dnsimple-personal",
           created_at: "2011-09-11T17:15:58Z",
           updated_at: "2016-06-03T15:02:26Z",

--- a/test/domain_pushes.spec.ts
+++ b/test/domain_pushes.spec.ts
@@ -45,6 +45,25 @@ describe("domains", () => {
     });
   });
 
+  describe("#initiatePush with domain push identifier", () => {
+    const accountId = 1010;
+    const domainId = "example.com";
+    const attributes = { new_domain_push_identifier: "abc123" };
+
+    it("builds the correct request", async () => {
+      fetchMock.post(
+        "https://api.dnsimple.com/v2/1010/domains/example.com/pushes",
+        responseFromFixture("initiatePush/success.http")
+      );
+
+      await dnsimple.domains.initiatePush(accountId, domainId, attributes);
+
+      expect(fetchMock.callHistory.lastCall().options.body).toEqual(
+        JSON.stringify(attributes)
+      );
+    });
+  });
+
   describe("#listPushes", () => {
     const accountId = 1010;
 

--- a/test/domain_pushes.spec.ts
+++ b/test/domain_pushes.spec.ts
@@ -48,7 +48,7 @@ describe("domains", () => {
   describe("#initiatePush with domain push identifier", () => {
     const accountId = 1010;
     const domainId = "example.com";
-    const attributes = { new_domain_push_identifier: "abc123" };
+    const attributes = { new_account_identifier: "abc123" };
 
     it("builds the correct request", async () => {
       fetchMock.post(

--- a/test/fixtures.http/accounts/success-account.http
+++ b/test/fixtures.http/accounts/success-account.http
@@ -17,4 +17,4 @@ x-permitted-cross-domain-policies: none
 x-xss-protection: 1; mode=block
 strict-transport-security: max-age=31536000
 
-{"data":[{"id":123,"email":"john@example.com","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"}]}
+{"data":[{"id":123,"email":"john@example.com","name":"John","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"}]}

--- a/test/fixtures.http/accounts/success-user.http
+++ b/test/fixtures.http/accounts/success-user.http
@@ -17,5 +17,5 @@ x-permitted-cross-domain-policies: none
 x-xss-protection: 1; mode=block
 strict-transport-security: max-age=31536000
 
-{"data":[{"id":123,"email":"john@example.com","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"},{"id":456,"email":"ops@company.com","plan_identifier":"teams-v1-monthly","created_at":"2012-03-16T16:02:54Z","updated_at":"2016-06-14T11:23:16Z"}]}
+{"data":[{"id":123,"email":"john@example.com","name":"John","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"},{"id":456,"email":"ops@company.com","name":"Ops Company","plan_identifier":"teams-v1-monthly","created_at":"2012-03-16T16:02:54Z","updated_at":"2016-06-14T11:23:16Z"}]}
 

--- a/test/fixtures.http/listAccounts/success-account.http
+++ b/test/fixtures.http/listAccounts/success-account.http
@@ -17,4 +17,4 @@ x-permitted-cross-domain-policies: none
 x-xss-protection: 1; mode=block
 strict-transport-security: max-age=31536000
 
-{"data":[{"id":123,"email":"john@example.com","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"}]}
+{"data":[{"id":123,"email":"john@example.com","name":"John","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"}]}

--- a/test/fixtures.http/listAccounts/success-user.http
+++ b/test/fixtures.http/listAccounts/success-user.http
@@ -17,4 +17,4 @@ x-permitted-cross-domain-policies: none
 x-xss-protection: 1; mode=block
 strict-transport-security: max-age=31536000
 
-{"data":[{"id":123,"email":"john@example.com","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"},{"id":456,"email":"ops@company.com","plan_identifier":"teams-v1-monthly","created_at":"2012-03-16T16:02:54Z","updated_at":"2016-06-14T11:23:16Z"}]}
+{"data":[{"id":123,"email":"john@example.com","name":"John","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"},{"id":456,"email":"ops@company.com","name":"Ops Company","plan_identifier":"teams-v1-monthly","created_at":"2012-03-16T16:02:54Z","updated_at":"2016-06-14T11:23:16Z"}]}

--- a/test/fixtures.http/whoami/success-account.http
+++ b/test/fixtures.http/whoami/success-account.http
@@ -12,4 +12,4 @@ x-request-id: 15a7f3a5-7ee5-4e36-ac5a-8c21c2e1fffd
 x-runtime: 0.141588
 strict-transport-security: max-age=31536000
 
-{"data":{"user":null,"account":{"id":1,"email":"example-account@example.com","plan_identifier":"teams-v1-monthly","created_at":"2015-09-18T23:04:37Z","updated_at":"2016-06-09T20:03:39Z"}}}
+{"data":{"user":null,"account":{"id":1,"email":"example-account@example.com","name":"Example Account","plan_identifier":"teams-v1-monthly","created_at":"2015-09-18T23:04:37Z","updated_at":"2016-06-09T20:03:39Z"}}}

--- a/test/fixtures.http/whoami/success.http
+++ b/test/fixtures.http/whoami/success.http
@@ -12,4 +12,4 @@ x-request-id: 15a7f3a5-7ee5-4e36-ac5a-8c21c2e1fffd
 x-runtime: 0.141588
 strict-transport-security: max-age=31536000
 
-{"data":{"user":null,"account":{"id":1,"email":"example-account@example.com","plan_identifier":"teams-v1-monthly","created_at":"2015-09-18T23:04:37Z","updated_at":"2016-06-09T20:03:39Z"}}}
+{"data":{"user":null,"account":{"id":1,"email":"example-account@example.com","name":"Example Account","plan_identifier":"teams-v1-monthly","created_at":"2015-09-18T23:04:37Z","updated_at":"2016-06-09T20:03:39Z"}}}


### PR DESCRIPTION
## Summary
- Add `new_domain_push_identifier` parameter for domain pushes
- Deprecate `new_account_email` in favor of `new_domain_push_identifier`
- Add `name` field to `Account` type
- Update fixtures and tests

Closes dnsimple/dnsimple-engineering#425