### PR TITLE
Support trustee service in transfers

### DIFF
--- a/lib/registrar.ts
+++ b/lib/registrar.ts
@@ -142,6 +142,7 @@ export class Registrar {
         registrant_id: number;
         auth_code: string;
         whois_privacy: boolean;
+        trustee_service: boolean;
         auto_renew: boolean;
         extended_attributes: {};
         premium_price: string;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -242,6 +242,7 @@ export type DomainTransfer = {
   state: "cancelled" | "new" | "transferring" | "transferred" | "failed";
   auto_renew: boolean;
   whois_privacy: boolean;
+  trustee_service: boolean;
   status_description: string;
   created_at: string;
   updated_at: string;

--- a/test/registrar.spec.ts
+++ b/test/registrar.spec.ts
@@ -177,6 +177,7 @@ describe("registrar", () => {
       const domain = response.data;
       expect(domain.id).toBe(1);
       expect(domain.state).toBe("transferring");
+      expect(domain.trustee_service).toBe(false);
     });
 
     describe("when the domain is already in DNSimple", () => {
@@ -226,6 +227,7 @@ describe("registrar", () => {
       expect(domainTransfer.state).toBe("cancelled");
       expect(domainTransfer.auto_renew).toBe(false);
       expect(domainTransfer.whois_privacy).toBe(false);
+      expect(domainTransfer.trustee_service).toBe(false);
       expect(domainTransfer.status_description).toBe("Canceled by customer");
       expect(domainTransfer.created_at).toBe("2020-06-05T18:08:00Z");
       expect(domainTransfer.updated_at).toBe("2020-06-05T18:10:01Z");
@@ -252,6 +254,7 @@ describe("registrar", () => {
       expect(domainTransfer.state).toBe("transferring");
       expect(domainTransfer.auto_renew).toBe(false);
       expect(domainTransfer.whois_privacy).toBe(false);
+      expect(domainTransfer.trustee_service).toBe(false);
       expect(domainTransfer.status_description).toBe(null);
       expect(domainTransfer.created_at).toBe("2020-06-05T18:08:00Z");
       expect(domainTransfer.updated_at).toBe("2020-06-05T18:08:04Z");


### PR DESCRIPTION
Updated **lib/types.ts**
- Added `trustee_service` field to the `DomainTransfer` type so the value is parsed from API responses

Updated **lib/registrar.ts**
- Added `trustee_service` parameter to the `transferDomain` input so callers can opt into the trustee service when initiating a transfer

Addresses https://github.com/dnsimple/dnsimple-app/issues/34694
Belongs to https://github.com/dnsimple/dnsimple-business/issues/2641

## QA

(Optional for reviewers)

From the console (adjust `accountId`, `registrantId`, `domainName` and `baseUrl` accordingly) run `node qa_transfer_trustee.mjs`

```javascript
import { createRequire } from "module";
const require = createRequire(import.meta.url);
const { DNSimple } = require("./dist/lib/main.js");

const token = process.env.TOKEN;
if (!token) {
  console.error("ERROR: TOKEN environment variable is required");
  process.exit(1);
}

const client = new DNSimple({
  accessToken: token,
  baseUrl: "http://api.dnsimple.localhost:3000",
});

const accountId = 2;
const registrantId = 27;
const domainName = "example.com";

// Transfer a domain with trustee service enabled
try {
  const response = await client.registrar.transferDomain(accountId, domainName, {
    registrant_id: registrantId,
    auth_code: "x1y2z3",
    trustee_service: true,
  });
  const transfer = response.data;
  console.log(`transfer domain_id=${transfer.domain_id} trustee_service=${transfer.trustee_service} state=${transfer.state}`);

  // Get the domain transfer to verify
  const got = await client.registrar.getDomainTransfer(accountId, domainName, transfer.id);
  const t = got.data;
  console.log(`get_transfer id=${t.id} trustee_service=${t.trustee_service} state=${t.state}`);
} catch (e) {
  console.log(`(${e.status})\nHTTP response body: ${JSON.stringify(e.data)}`);
}
```

#### QA results

```
(400)
HTTP response body: {"message":"TLD .COM does not support trustee service"}
```

```
(400)
HTTP response body: {"message":"Unable to complete transfer at the registrar. Invalid attribute value syntax [Parameter value syntax error; Invalid transfer authorisation code]","errors":{}}
```

## Deployment Pre/Post tasks

- [x] PRE: Wait till release is ready to be made
- [x] POST: Create a release version

## Deployment Verification

- [x] Verify release is created