### PR TITLE
Remove deprecated Certificate contact_id field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project uses [Semantic Versioning 2.0.0](http://semver.org/), the format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## main
+
+### Removed
+
+- **BREAKING**: Removed the deprecated `contact_id` field from the `Certificate` type. The field was deprecated on 2022-05-17 and is no longer required for certificate operations.
+
 ## 12.3.0 - 2026-04-16
 
 ### Added

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -115,7 +115,6 @@ export type Push = {
 export type Certificate = {
   id: number;
   domain_id: number;
-  contact_id: number;
   name: string;
   common_name: string;
   years: number;

--- a/test/certificates.spec.ts
+++ b/test/certificates.spec.ts
@@ -135,7 +135,6 @@ describe("certificates", () => {
       const certificate = response.data;
       expect(certificate.id).toBe(101967);
       expect(certificate.domain_id).toBe(289333);
-      expect(certificate.contact_id).toBe(2511);
       expect(certificate.common_name).toBe("www.bingo.pizza");
       expect(certificate.alternate_names).toEqual([]);
       expect(certificate.state).toBe("issued");


### PR DESCRIPTION
## Summary

Remove the deprecated `contact_id` field from the `Certificate` type. The field was deprecated on 2022-05-17 and is no longer required for certificate operations.

This is a breaking change.

Tracking PR: dnsimple/dnsimple-developer#987

## Test plan

- [x] Existing tests updated to not reference `contact_id`
- [x] Tests pass