### PR TITLE
Make webhook and zone timestamps nullable

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -291,7 +291,7 @@ export type Zone = {
   name: string;
   reverse: boolean;
   secondary: boolean;
-  last_transferred_at: string;
+  last_transferred_at: NullableDateTime;
   active: boolean;
   created_at: string;
   updated_at: string;
@@ -401,7 +401,7 @@ export type VanityNameServer = {
   updated_at: string;
 };
 
-export type Webhook = { id: number; url: string; suppressed_at: string };
+export type Webhook = { id: number; url: string; suppressed_at: NullableDateTime };
 
 export type RegistrantChange = {
   id: number;


### PR DESCRIPTION
## Description
This PR fixes type-mismatch bugs between the TypeScript definitions and the SDK's internal API mock fixtures.

### Fixes
* **Webhook.suppressed_at**: Updated from `string` to `NullableDateTime`. Active webhooks return `null` when not suppressed, which caused a type mismatch against the strict `string` definition.
* **Zone.last_transferred_at**: Updated from `string` to `NullableDateTime`. Profiles for domains or zones that have not undergone an external transfer return `null`.

All test suites pass cleanly with zero regressions.